### PR TITLE
Velocity patterns

### DIFF
--- a/Sound/Tidal/VolcaBass.hs
+++ b/Sound/Tidal/VolcaBass.hs
@@ -44,6 +44,7 @@ bass = OscShape {path = "/note",
                             F "cutoff" (Just (-1)),
                             F "gate" (Just (-1))
                           ],
+                 cpsStamp = False,
                  timestamp = NoStamp,
                  latency = 0,
                  namedParams = False,

--- a/Sound/Tidal/VolcaKeys.hs
+++ b/Sound/Tidal/VolcaKeys.hs
@@ -49,6 +49,7 @@ keys = OscShape {path = "/note",
                             F "dtime" (Just (-1)),
                             F "dfeedback" (Just (-1))
                           ],
+                 cpsStamp = False,
                  timestamp = NoStamp,
                  latency = 0,
                  namedParams = False,


### PR DESCRIPTION
Hello,

I made a quick patch so that you can create velocity patterns, e.g.:

    keys $ note "80 80 80 80" |+| vel "1 0.3"

The patch also includes the missing cpsStamp parameter fix, which has been floating around for a while but is not in the official repo yet.
