### PR TITLE
Making Tidal MIDI available on major platforms and more devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,153 @@
 # tidal-midi
 Tidal module for sending patterns over MIDI.
-Currently only supports the Volca Keys synth.
+
+__PortMIDI__ variant. Should work on OS X, Linux and Windows
+
+This _still_ is __experimental__ software
+
+## Installation
+
+Currently you will have to clone this repository and install from source:
+
+```shell
+~$ git clone https://github.com/lennart/tidal-midi.git
+~$ cd tidal-midi
+~/tidal-midi$ cabal install
+```
+
+After that you can import Sound.Tidal.MIDI.Output within Haskell. To make use of tidal-midi within emacs and running along with tidal, depending on your editor you will have to edit the load script for tidal.
+
+### Setup for emacs
+
+Within your `tidal.el` script, locate the function `tidal-start-haskell` and add:
+
+```emacs
+(tidal-send-string "import Sound.Tidal.MIDI.Output")
+```
+
+after
+
+```emacs
+(tidal-send-string "import Sound.Tidal.Context")
+```
+
+Additionally you will have to add lines to import the synth you want to control via MIDI, e.g. `(tidal-send-string "import Sound.Tidal.SimpleSynth")` as well as the initialization commands for streams:
+
+```emacs
+(tidal-send-string "keyStreams <- midiproxy 1 \"SimpleSynth virtual input\" [(keys, 1)]")
+(tidal-send-string "[t1] <- sequence keyStreams")
+```
+For adding the MIDI device "SimpleSynth virtual input" and control it via MIDI channel 1. With this set up you will be able to use it via e.g. `t1 $ note "50"`
+
+Synth specific usage instructions can be found below. Note that these are simply assuming you are running tidal-midi directly via ghci command line. If you want any of the other synths within emacs, you will have to edit your `tidal.el` accordingly.
+
+## Usage
+
+in your `.ghci` add the following, given you need an _additional_ latency of __1ms__, your _device name_ is __SimpleSynth virtual input__ and you want to send commands on MIDI channel __1__:
+
+```haskell
+import Sound.Tidal.MIDI.Output
+import Sound.Tidal.SimpleSynth
+
+keyStreams <- midiproxy 1 "SimpleSynth virtual input" [(keys, 1)]
+
+[k1] <- sequence keyStreams
+```
+
+You can alter the latency to fit your other sources (e.g. audio buffers etc.), but be aware that there is _already 100ms latency added_ to make sure incoming osc commands can be scheduled in the future. Note that the given latency is directly passed to __PortMidi__ `openOutput` which will send real-time __MIDI__ messages for latency __0__ which may or may not be what you want.
+
+To find out a particular device name you can use `aconnect -o` on linux and the __Audio MIDI Setup__ on Mac OS X.
+
+Channels can be multiple, e.g. for polyphonic synthesizers this makes it possible to have separate streams (like d1-9 for dirt) for each midi channel on the same device.
+
+`keys` in this case refers to the `ControllerShape` defined by the example simple synth. See [other supported synths](#supported-synths)
+
+Eventually run `ghci -XOverloadedStrings` and send __MIDI__ commands to a compliant device (software synth).
+
+```haskell
+k1 $ note "50*4" |+| slow 2 (modwheel (scale 0.2 0.9 tri1))
+```
+
+The simple synth comes with _simple_ MIDI parameters, that any device should understand:
+
+* modwheel
+* balance
+* expression
+* sustainpedal
+
+all of these parameters map the given values from __0..1__ to MIDI values ranging from __0..127__.
+
+## Supported Synths
+
+### Korg Volca Keys
+
+Example:
+```haskell
+import Sound.Tidal.MIDI.Output
+import Sound.Tidal.VolcaKeys
+
+keyStreams <- midiproxy 1 "VolcaKeys" [(keys, 1)]
+
+[k1] <- sequence keyStreams
+```
+
+### Korg Volca Bass
+
+Example:
+```haskell
+import Sound.Tidal.MIDI.Output
+import Sound.Tidal.VolcaBass
+
+bassStreams <- midiproxy 1 "VolcaBass" [(bass, 1)]
+
+[k1] <- sequence bassStreams
+```
+
+
+### Korg Volca Beats
+
+Example:
+```haskell
+import Sound.Tidal.MIDI.Output
+import Sound.Tidal.VolcaBeats
+
+beatStreams <- midiproxy 1 "VolcaBeats" [(beats, 1)]
+
+[k1] <- sequence beatStreams
+```
+
+### Waldorf Blofeld
+
+Example:
+
+```haskell
+import Sound.Tidal.MIDI.Output
+import Sound.Tidal.Blofeld
+
+keyStreams <- midiproxy 1 "Waldorf Blofeld" [(keys, 1)]
+
+[k1] <- sequence keyStreams
+```
+
+### DSI Tetra
+
+#### Example
+
+assumes the following Tetra Global parameters:
+
+* `Multi mode`: __On__
+* `M Param Rec`: __NRPN__
+* `MIDI Channel`: __1__
+
+```haskell
+import Sound.Tidal.MIDI.Output
+import Sound.Tidal.Tetra
+
+keyStreams <- midiproxy 1 "DSI Tetra" [(keys 1),(keys, 2),(keys, 3),(keys, 4)]
+
+[k1,k2,k3,k4] <- sequence keyStreams
+```
+
+## Known issues and limitations
+
+- SysEx support is there but really limited to work with the Waldorf Blofeld

--- a/Sound/Tidal/Blofeld.hs
+++ b/Sound/Tidal/Blofeld.hs
@@ -1,0 +1,78 @@
+module Sound.Tidal.Blofeld where
+
+import Sound.Tidal.Stream (makeI, makeF)
+
+import Sound.Tidal.MIDI.Control
+
+keys :: ControllerShape
+keys = ControllerShape {params = [
+                          mCC "portamento" 5,
+                          mCC "expression" 11,
+                          CC "lfoshape" 15 (0, 5) 0 passThru, -- 0..5 - sine,triangle,square,saw,random,sample&hold
+                          mCC "lforate" 16,
+                          CC "lfosync" 17 (0, 1) 0 passThru, -- 0 off, 1 on
+                          mCC "lfodelay" 18,
+                          CC "octave" 27 (16, 112) 0 passThru, -- 16, 28, 40 .. 112 - 128' .. 1/2'
+                          CC "semitone" 28 (52, 76) 0.5 passThru, -- 52 .. 76 - -12 - +12 semitones
+                          mCC "detune" 29,
+                          mCC "osc1fm" 30,
+                          SysEx "osc1fmsrc" 6 (0, 11) 0 passThru,
+                          CC "osc1shape" 31 (0, 5) 0 passThru, -- 0..5 - pulse, saw, tri, sine, alt 1, alt 2
+                          mCC "osc1pw" 33,
+                          mCC "osc1pwm" 34,
+                          SysEx "osc1pwmsrc" 10 (0, 30) 0 passThru,
+                          mCC "osc1vol" 52,
+                          mCC "osc1pan" 53,
+                          mCC "ringmod" 54,
+                          mCC "ringpan" 55,
+                          mCC "noise" 60,
+                          mCC "noisepan" 61,
+                          mCC "noisecol" 62,
+                          mCC "kcutoff" 69,
+                          mCC "attack" 101,
+                          mCC "decay" 102,
+                          mCC "sustain" 103,
+                          mCC "release" 106
+                        ],
+                        duration = ("dur", 0.05),
+                        velocity = ("vel", 0.5),
+                        latency = 0.1}
+
+oscKeys = toOscShape keys
+
+note         = makeI oscKeys "note"
+dur          = makeF oscKeys "dur"
+
+portamento   = makeF oscKeys "portamento"
+expression   = makeF oscKeys "expression"
+octave       = makeF oscKeys "octave"
+semitone       = makeF oscKeys "semitone"
+detune       = makeF oscKeys "detune"
+
+kcutoff      = makeF oscKeys "kcutoff"
+
+lforate      = makeF oscKeys "lforate"
+lfoshape     = makeF oscKeys "lfoshape"
+lfodelay     = makeF oscKeys "lfodelay"
+lfosync     = makeF oscKeys "lfosyn"
+
+attack       = makeF oscKeys "attack"
+decay        = makeF oscKeys "decay"
+sustain      = makeF oscKeys "sustain"
+release      = makeF oscKeys "release"
+
+osc1fm = makeF oscKeys "osc1fm"
+osc1fmsrc = makeF oscKeys "osc1fmsrc"
+osc1shape = makeF oscKeys "osc1shape"
+osc1pw = makeF oscKeys "osc1pw"
+osc1pwm = makeF oscKeys "osc1pwm"
+osc1pwmsrc = makeF oscKeys "osc1pwmsrc"
+osc1vol = makeF oscKeys "osc1vol"
+osc1pan = makeF oscKeys "osc1pan"
+
+ringmod = makeF oscKeys "ringmod"
+ringpan = makeF oscKeys "ringpan"
+
+noise = makeF oscKeys "noise"
+noisepan = makeF oscKeys "noisepan"
+noisecol = makeF oscKeys "noisecol"

--- a/Sound/Tidal/MBase01.hs
+++ b/Sound/Tidal/MBase01.hs
@@ -1,0 +1,34 @@
+module Sound.Tidal.MBase01 where
+import Sound.Tidal.Stream (makeI, makeF)
+
+import Sound.Tidal.MIDI.Control
+
+mbase01 :: ControllerShape
+mbase01 = ControllerShape {params = [
+                          mCC "tune" 100,
+                          mCC "pitch" 101,
+                          mCC "decay" 102,
+                          mCC "harmonics" 103,
+                          mCC "pulse" 104,
+                          mCC "noise" 105,
+                          mCC "attack" 106,
+                          mCC "eqlzr" 107
+                        ],
+                        duration = ("dur", 0.05),
+                        velocity = ("vel", 0.5),
+                        latency = 0.1}
+
+oscKeys = toOscShape mbase01
+
+note         = makeI oscKeys "note"
+dur          = makeF oscKeys "dur"
+
+
+tune = makeF oscKeys "tune"
+pitch = makeF oscKeys "pitch"
+decay = makeF oscKeys "decay"
+harmonics = makeF oscKeys "harmonics"
+pulse = makeF oscKeys "pulse"
+noise = makeF oscKeys "noise"
+attack = makeF oscKeys "attack"
+eqlzr = makeF oscKeys "eqlzr"

--- a/Sound/Tidal/MIDI/Control.hs
+++ b/Sound/Tidal/MIDI/Control.hs
@@ -2,7 +2,6 @@ module Sound.Tidal.MIDI.Control where
 
 import qualified Sound.Tidal.Stream as S
 
-
 type RangeMapFunc = (Int, Int) -> Float -> Int
 
 data Param = CC { name :: String, midi :: Int, range :: (Int, Int), vdefault :: Double, scalef :: RangeMapFunc }
@@ -33,15 +32,22 @@ mapRange :: (Int, Int) -> Float -> Int
 mapRange (low, high) = floor . (+ (fromIntegral low)) . (* ratio)
   where ratio = fromIntegral $ high - low
 
-
+mCC :: String -> Int -> Param
 mCC n m = CC {name=n, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+
+mNRPN :: String -> Int -> Param
 mNRPN n m = NRPN {name=n, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+
+mrNRPN :: String -> Int -> (Int, Int) -> Double -> Param
 mrNRPN n m r d = NRPN {name=n, midi=m, range=r, vdefault=d, scalef=mapRange }
+
 toKeynames :: ControllerShape -> [String]
 toKeynames shape = map name (params shape)
 
+ctrlN :: Num b => ControllerShape -> String -> b
 ctrlN shape x = fromIntegral $ midi $ paramN shape x
 
+paramN :: ControllerShape -> String -> Param
 paramN shape x
   | x `elem` names = paramX x
   | otherwise = error $ "No such Controller param: " ++ show x

--- a/Sound/Tidal/MIDI/Control.hs
+++ b/Sound/Tidal/MIDI/Control.hs
@@ -1,0 +1,51 @@
+module Sound.Tidal.MIDI.Control where
+
+import qualified Sound.Tidal.Stream as S
+
+
+type RangeMapFunc = (Int, Int) -> Float -> Int
+
+data Param = CC { name :: String, midi :: Int, range :: (Int, Int), vdefault :: Double, scalef :: RangeMapFunc }
+           | NRPN { name :: String, midi :: Int, range :: (Int, Int), vdefault :: Double, scalef :: RangeMapFunc }
+           | SysEx { name :: String, midi :: Int, range :: (Int, Int), vdefault :: Double, scalef :: RangeMapFunc }
+
+data ControllerShape = ControllerShape {params :: [Param],duration :: (String, Double), velocity :: (String, Double), latency :: Double}
+
+toOscShape :: ControllerShape -> S.OscShape
+toOscShape cs =
+  let oscparams = [S.I "note" Nothing] ++ [S.F durn (Just durv), S.F veln (Just velv)] ++ oscparams'
+      oscparams' = [S.F (name p) (Just (-1)) | p <- (params cs)]
+      (durn, durv) = duration cs
+      (veln, velv) = velocity cs
+  in S.OscShape {S.path = "/note",
+                 S.params = oscparams,
+                 S.timestamp = S.MessageStamp,
+                 S.cpsStamp = False,
+                 S.latency = latency cs,
+                 S.namedParams = False,
+                 S.preamble = []
+                }
+
+passThru :: (Int, Int) -> Float -> Int
+passThru (_, _) = floor -- no sanitizing of range…
+
+mapRange :: (Int, Int) -> Float -> Int
+mapRange (low, high) = floor . (+ (fromIntegral low)) . (* ratio)
+  where ratio = fromIntegral $ high - low
+
+
+mCC n m = CC {name=n, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+mNRPN n m = NRPN {name=n, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+mrNRPN n m r d = NRPN {name=n, midi=m, range=r, vdefault=d, scalef=mapRange }
+toKeynames :: ControllerShape -> [String]
+toKeynames shape = map name (params shape)
+
+ctrlN shape x = fromIntegral $ midi $ paramN shape x
+
+paramN shape x
+  | x `elem` names = paramX x
+  | otherwise = error $ "No such Controller param: " ++ show x
+  where names = toKeynames shape
+        paramX x = head paramX'
+        paramX' = filter ((== x) . name) p
+        p = params shape

--- a/Sound/Tidal/MIDI/Device.hs
+++ b/Sound/Tidal/MIDI/Device.hs
@@ -1,11 +1,7 @@
 module Sound.Tidal.MIDI.Device where
 import qualified Sound.PortMidi as PM
-import Control.Exception
-import Data.List
 
-
---withPortMidi = bracket_ PM.initialize PM.terminate
-
+displayOutputDevices :: IO String
 displayOutputDevices = do
   devices <- getIndexedDevices
   return $ displayDevices $ getOutputDevices devices
@@ -17,8 +13,10 @@ displayDevices devices =
       pairs = zipWith (++) indices names
   in unlines (["ID:\tName"]++pairs)
 
+getOutputDevices :: [(a, PM.DeviceInfo)] -> [(a, PM.DeviceInfo)]
 getOutputDevices = filter (PM.output . snd)
 
+getIndexedDevices :: IO [(Integer, PM.DeviceInfo)]
 getIndexedDevices = do
   rawDevices <- getDevices
   return $ zip [0..] rawDevices
@@ -29,13 +27,10 @@ getDevices = do
   count <- PM.countDevices
   mapM PM.getDeviceInfo [0..(count - 1)]
 
-
+getIDForDeviceName :: Num a => String -> IO (Maybe a)
 getIDForDeviceName name = do
   odevs <- fmap getOutputDevices getIndexedDevices
   let res = filter (\n -> (PM.name . snd) n == name) odevs
   case res of
     [] -> return Nothing
     [dev] -> return $ Just $ fromIntegral $ fst dev
-
---main = do
---  putStrLn =<< displayOutputDevices

--- a/Sound/Tidal/MIDI/Device.hs
+++ b/Sound/Tidal/MIDI/Device.hs
@@ -1,0 +1,41 @@
+module Sound.Tidal.MIDI.Device where
+import qualified Sound.PortMidi as PM
+import Control.Exception
+import Data.List
+
+
+--withPortMidi = bracket_ PM.initialize PM.terminate
+
+displayOutputDevices = do
+  devices <- getIndexedDevices
+  return $ displayDevices $ getOutputDevices devices
+
+displayDevices :: Show a => [(a, PM.DeviceInfo)] -> String
+displayDevices devices =
+  let indices = map (show . fst) devices
+      names = map ((":\t"++) . PM.name . snd) devices
+      pairs = zipWith (++) indices names
+  in unlines (["ID:\tName"]++pairs)
+
+getOutputDevices = filter (PM.output . snd)
+
+getIndexedDevices = do
+  rawDevices <- getDevices
+  return $ zip [0..] rawDevices
+
+getDevices :: IO ([PM.DeviceInfo])
+getDevices = do
+  PM.initialize
+  count <- PM.countDevices
+  mapM PM.getDeviceInfo [0..(count - 1)]
+
+
+getIDForDeviceName name = do
+  odevs <- fmap getOutputDevices getIndexedDevices
+  let res = filter (\n -> (PM.name . snd) n == name) odevs
+  case res of
+    [] -> return Nothing
+    [dev] -> return $ Just $ fromIntegral $ fst dev
+
+--main = do
+--  putStrLn =<< displayOutputDevices

--- a/Sound/Tidal/MIDI/Output.hs
+++ b/Sound/Tidal/MIDI/Output.hs
@@ -1,0 +1,248 @@
+module Sound.Tidal.MIDI.Output where
+
+import qualified Sound.PortMidi as PM
+
+import Sound.Tidal.MIDI.Device
+
+import Data.Time (getCurrentTime, UTCTime, diffUTCTime)
+import Data.Time.Clock.POSIX
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as BC
+
+import Numeric
+
+import Sound.OSC.FD
+
+
+import Control.Monad
+import Control.Concurrent.MVar
+
+import Data.Bits
+import Data.Char
+import Data.List (sortBy)
+import Data.Maybe
+import Data.Ord (comparing)
+
+import Control.Concurrent
+import Foreign.C
+
+import qualified Sound.Tidal.MIDI.Control as C
+
+import Sound.Tidal.Pattern
+import Sound.Tidal.Parse
+import Sound.Tidal.Tempo
+import qualified Sound.Tidal.Stream as S (stream, name, params)
+
+import System.IO.Error
+
+data Output = Output {
+                       conn :: PM.PMStream,
+                       lock :: MVar (),
+                       offset :: (Int, Int),
+                       buffer :: MVar [PM.PMEvent]
+                     }
+
+messageLoop stream shape ch port = do
+  putStrLn ("Starting message loop on port " ++ show port ++ " for MIDI channel " ++ show ch)
+  x <- udpServer "127.0.0.1" port
+
+  forkIO $ loop stream x ch
+    where loop stream x ch = do m <- recvMessage x
+                                act stream m ch
+                                loop stream x ch
+          act stream (Just (Message "/note" (sec:usec:note:dur:vel:ctrls))) ch =
+              do
+                let diff = timeDiff (sec, usec) (offset stream)
+                    note' = (fromJust $ d_get note) :: Int
+                    vel' = (fromJust $ d_get vel) :: Float
+                    dur' = (fromJust $ d_get dur) :: Float
+                    ctrls' = (map (fromJust . d_get) ctrls) :: [Float]
+
+                -- mTime <- PM.time
+                -- putStrLn ("MIDI in: " ++ (show (diff - mTime)))
+                sendmidi stream shape ch (fromIntegral note', fromIntegral $ C.mapRange (0, 127) (realToFrac vel'), realToFrac dur') (diff) ctrls'
+                return()
+makeStream shape port = S.stream "127.0.0.1" port shape
+
+midiproxy latency deviceName targets = do
+  let keyStreams = map (\(shape, channel) -> makeStream (C.toOscShape shape) (channel + 7303)) targets
+  deviceID <- getIDForDeviceName deviceName
+  case deviceID of
+    Nothing -> do putStrLn "List of Available Device Names"
+                  putStrLn =<< displayOutputDevices
+                  error ("Device '" ++ show deviceName ++ "' not found")
+    Just id -> do econn <- outputDevice id latency
+                  case econn of
+                       Right err -> error ("Failed opening MIDI Output on Device ID: " ++ show deviceID ++ " - " ++ show err)
+                       Left conn -> do
+                         sendevents conn
+                         --midiclock conn
+                         mapM_ (\(shape,channel) -> messageLoop conn shape (fromIntegral channel) (channel + 7303)) targets
+                         return keyStreams
+
+midiclock stream = do
+  forkIO $ do clockedTick 1 $ onClockTick stream
+
+onClockTick stream current ticks = do
+  -- schedule MIDI Clock Ticks ahead of time to avoid jumps in timing
+  -- e.g. if one tick per cycle
+  -- schedule 24 ticks ahead of time starting now with PM.time and incrementing each timestamp by ((1/cycle per seconds)/24)*1000 for ms for each tick
+  time <- PM.time
+  mapM_ (makeMidiClockTick stream) (map ((+time).round.(/(24*(cps current))).(*1000)) [0..23])
+  return ()
+
+
+sendevents stream = do
+  forkIO $ do loop stream
+    where loop stream = do act stream
+                           delay
+                           loop stream
+          act stream = do
+            let buf = buffer stream
+                o = conn stream
+            buf' <- tryTakeMVar buf
+            case buf' of
+              Nothing ->  do
+                return Nothing
+              Just [] -> do
+                putMVar buf []
+                return Nothing
+              (Just evts@(x:xs)) -> do
+                midiTime <- PM.time
+                let evts' = sortBy (comparing PM.timestamp) evts
+                    nextTick = fromIntegral $ midiTime + 1 -- advance on millisecond, i.e. the next call of this loop
+                    (evts'',later) = span (\x -> (((PM.timestamp x) < midiTime)) || ((PM.timestamp x) < nextTick)) evts'
+                putMVar buf later
+
+                err <- PM.writeEvents o evts''
+                case err of
+                  PM.NoError -> return Nothing
+                  e -> return $ Just (userError ("Error '" ++ show e ++ "' sending Events: " ++ show evts))
+
+          delay = threadDelay 1000 -- in microseconds, i.e. one millisecond
+
+
+sendctrls stream shape ch t ctrls = do
+  let ctrls' = filter ((>=0) . snd) (zip (C.toKeynames shape) ctrls)
+  sequence_ $ map (\(name, ctrl) -> makeCtrl stream ch (C.paramN shape name) ctrl t) ctrls'
+  return ()
+
+sendnote stream shape ch (note,vel, dur) t =
+  do forkIO $ do noteOn stream ch note vel t
+                 noteOff stream ch note (t + (floor $ 1000 * dur))
+                 return ()
+
+sendmidi stream shape ch (128,vel,dur) t ctrls = do
+  sendctrls stream shape ch t ctrls
+  return ()
+sendmidi stream shape ch (note,vel,dur) t ctrls = do
+  sendnote stream shape ch (note,vel,dur) t
+  sendctrls stream shape ch t ctrls
+  return ()
+
+timeDiff (ds, du) (s, u) = diff d i
+    where diff a b = floor ((a - b) * 1000) -- as millis
+          d = asFrac jds jdu
+          i = asFrac s u
+          jds = (fromJust $ d_get ds) :: Int
+          jdu = (fromJust $ d_get du) :: Int
+          asFrac a b = (fromIntegral a) + ((fromIntegral b) * 0.000001)
+
+
+-- MIDI Utils
+encodeChannel ch cc = (((-) ch 1) .|. cc)
+
+-- MIDI Messages
+noteOn o ch val vel t = do
+  let evt = makeEvent 0x90 val ch vel t
+  sendEvent o evt
+
+noteOff o ch val t = do
+  let evt = makeEvent 0x80 val ch 60 t
+  sendEvent o evt
+
+makeCtrl o ch (C.CC {C.midi=midi, C.range=range, C.scalef=f}) n t = makeCC o ch (fromIntegral midi) scaledN t
+  where scaledN = fromIntegral (f range (n))
+makeCtrl o ch (C.NRPN {C.midi=midi, C.range=range, C.scalef=f}) n t = makeNRPN o ch (fromIntegral midi) scaledN t
+  where scaledN = fromIntegral $ (f range (n))
+makeCtrl o ch (C.SysEx {C.midi=midi, C.range=range, C.scalef=f}) n t = makeSysEx o ch (fromIntegral midi) scaledN t
+  where scaledN = fromIntegral $ (f range (n))
+
+
+-- This is sending CC
+makeCC o ch c n t = do
+  let evt = makeEvent 0xB0 c ch n t
+  sendEvent o evt
+
+-- This is sending NRPN
+makeNRPN o ch c n t = do
+  let nrpn = makeEvent 0xB0
+      evts = [nrpn 0x63 ch (shift (c .&. 0x3F80) (-7)) t,
+              nrpn 0x62 ch (c .&. 0x7F) t,
+              nrpn 0x06 ch (shift (n .&. 0x3F80) (-7)) t,
+              nrpn 0x26 ch (n .&. 0x7F) t
+             ]
+  mapM (sendEvent o) evts
+  return Nothing
+
+makeMidiClockTick o t = do
+  sendEvent o $ PM.PMEvent (PM.PMMsg 0xF8 0x00 0x00) t
+
+makeSysEx o ch c n t = do
+  let bytes = [0xF0, -- SysEx Start
+               0x3E, -- Vendor ID
+               0x13, -- Equipment ID
+               0x00, -- Device No.
+               0x20, -- Message ID
+               0x00, -- Location
+               shift (c .&. 0x3F80) (-7), -- Parameter Index high byte
+               (c .&. 0x7F), -- Parameter Index low byte
+               n, -- Parameter Value
+               0xF7 -- End of SysEx
+              ]
+
+      msg = B.pack $ bytes
+
+  sendSysEx o t (BC.unpack msg)
+
+-- PortMIDI Wrapper
+
+outputDevice deviceID latency = do
+  PM.initialize
+  now <- getCurrentTime
+  result <- PM.openOutput deviceID latency
+  case result of
+    Left dev ->
+      do
+        info <- PM.getDeviceInfo deviceID
+        putStrLn ("Opened: " ++ show (PM.interface info) ++ ": " ++ show (PM.name info))
+        sem <- newEmptyMVar
+        putMVar sem () -- initially fill MVar to be taken by the first user of this output
+        buffer <- newMVar []
+
+        midiOffset <- PM.time
+
+        let posixNow = realToFrac $ utcTimeToPOSIXSeconds now
+            syncedNow = posixNow - ((0.001*) $ fromIntegral midiOffset)
+            sec = floor syncedNow
+            usec = floor $ 1000000 * (syncedNow - (realToFrac sec))
+        return (Left Output { conn=dev, lock=sem, offset=(sec, usec), buffer=buffer })
+    Right err -> return (Right err)
+
+makeEvent st n ch v t = PM.PMEvent msg (t)
+  where msg = PM.PMMsg (encodeChannel ch st) (n) (v)
+
+sendSysEx o t msg = do
+  let sem = lock o
+  takeMVar sem
+  err <- PM.writeSysEx (conn o) t msg
+  putMVar sem ()
+  return Nothing
+
+-- now with a semaphore since PortMIDI is NOT thread safe
+sendEvent o evt = do
+  let sem = lock o
+      buf = buffer o
+  cbuf <- takeMVar buf
+  putMVar buf (cbuf ++ [evt])
+  return Nothing

--- a/Sound/Tidal/MIDI/Output.hs
+++ b/Sound/Tidal/MIDI/Output.hs
@@ -1,4 +1,4 @@
-module Sound.Tidal.MIDI.Output where
+module Sound.Tidal.MIDI.Output (midiproxy) where
 
 import qualified Sound.PortMidi as PM
 
@@ -9,11 +9,7 @@ import Data.Time.Clock.POSIX
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 
-import Numeric
-
 import Sound.OSC.FD
-
-
 import Control.Monad
 import Control.Concurrent.MVar
 
@@ -22,6 +18,7 @@ import Data.Char
 import Data.List (sortBy)
 import Data.Maybe
 import Data.Ord (comparing)
+import Data.Word (Word8)
 
 import Control.Concurrent
 import Foreign.C
@@ -29,9 +26,8 @@ import Foreign.C
 import qualified Sound.Tidal.MIDI.Control as C
 
 import Sound.Tidal.Pattern
-import Sound.Tidal.Parse
 import Sound.Tidal.Tempo
-import qualified Sound.Tidal.Stream as S (stream, name, params)
+import qualified Sound.Tidal.Stream as S (stream, name, params, OscPattern, OscShape)
 
 import System.IO.Error
 
@@ -41,7 +37,24 @@ data Output = Output {
                        offset :: (Int, Int),
                        buffer :: MVar [PM.PMEvent]
                      }
+midiproxy :: Int -> String-> [(C.ControllerShape, Int)] -> IO [IO (S.OscPattern -> IO ())]
+midiproxy latency deviceName targets = do
+  let keyStreams = map (\(shape, channel) -> makeStream (C.toOscShape shape) (channel + 7303)) targets
+  deviceID <- getIDForDeviceName deviceName
+  case deviceID of
+    Nothing -> do putStrLn "List of Available Device Names"
+                  putStrLn =<< displayOutputDevices
+                  error ("Device '" ++ show deviceName ++ "' not found")
+    Just id -> do econn <- outputDevice id latency
+                  case econn of
+                       Right err -> error ("Failed opening MIDI Output on Device ID: " ++ show deviceID ++ " - " ++ show err)
+                       Left conn -> do
+                         sendevents conn
+                         --midiclock conn
+                         mapM_ (\(shape,channel) -> messageLoop conn shape (fromIntegral channel) (channel + 7303)) targets
+                         return keyStreams
 
+messageLoop  :: Output -> C.ControllerShape -> CLong -> Int -> IO ThreadId
 messageLoop stream shape ch port = do
   putStrLn ("Starting message loop on port " ++ show port ++ " for MIDI channel " ++ show ch)
   x <- udpServer "127.0.0.1" port
@@ -62,24 +75,11 @@ messageLoop stream shape ch port = do
                 -- putStrLn ("MIDI in: " ++ (show (diff - mTime)))
                 sendmidi stream shape ch (fromIntegral note', fromIntegral $ C.mapRange (0, 127) (realToFrac vel'), realToFrac dur') (diff) ctrls'
                 return()
+
+makeStream :: S.OscShape -> Int -> IO (S.OscPattern -> IO ())
 makeStream shape port = S.stream "127.0.0.1" port shape
 
-midiproxy latency deviceName targets = do
-  let keyStreams = map (\(shape, channel) -> makeStream (C.toOscShape shape) (channel + 7303)) targets
-  deviceID <- getIDForDeviceName deviceName
-  case deviceID of
-    Nothing -> do putStrLn "List of Available Device Names"
-                  putStrLn =<< displayOutputDevices
-                  error ("Device '" ++ show deviceName ++ "' not found")
-    Just id -> do econn <- outputDevice id latency
-                  case econn of
-                       Right err -> error ("Failed opening MIDI Output on Device ID: " ++ show deviceID ++ " - " ++ show err)
-                       Left conn -> do
-                         sendevents conn
-                         --midiclock conn
-                         mapM_ (\(shape,channel) -> messageLoop conn shape (fromIntegral channel) (channel + 7303)) targets
-                         return keyStreams
-
+-- EXPERIMENTAL
 midiclock stream = do
   forkIO $ do clockedTick 1 $ onClockTick stream
 
@@ -90,8 +90,9 @@ onClockTick stream current ticks = do
   time <- PM.time
   mapM_ (makeMidiClockTick stream) (map ((+time).round.(/(24*(cps current))).(*1000)) [0..23])
   return ()
+-- END EXPERIMENTAL
 
-
+sendevents :: Output -> IO ThreadId
 sendevents stream = do
   forkIO $ do loop stream
     where loop stream = do act stream
@@ -121,17 +122,19 @@ sendevents stream = do
 
           delay = threadDelay 1000 -- in microseconds, i.e. one millisecond
 
-
+sendctrls  :: Output -> C.ControllerShape -> CLong -> CULong -> [Float] -> IO ()
 sendctrls stream shape ch t ctrls = do
   let ctrls' = filter ((>=0) . snd) (zip (C.toKeynames shape) ctrls)
   sequence_ $ map (\(name, ctrl) -> makeCtrl stream ch (C.paramN shape name) ctrl t) ctrls'
   return ()
 
+sendnote :: RealFrac s => Output -> t -> CLong -> (CLong, CLong, s) -> CULong -> IO ThreadId
 sendnote stream shape ch (note,vel, dur) t =
   do forkIO $ do noteOn stream ch note vel t
                  noteOff stream ch note (t + (floor $ 1000 * dur))
                  return ()
 
+sendmidi :: RealFrac s => Output -> C.ControllerShape -> CLong -> (CLong, CLong, s) -> CULong -> [Float] -> IO ()
 sendmidi stream shape ch (128,vel,dur) t ctrls = do
   sendctrls stream shape ch t ctrls
   return ()
@@ -140,6 +143,7 @@ sendmidi stream shape ch (note,vel,dur) t ctrls = do
   sendctrls stream shape ch t ctrls
   return ()
 
+timeDiff :: (Integral b, Integral a1, Integral a) => (Datum, Datum) -> (a, a1) -> b
 timeDiff (ds, du) (s, u) = diff d i
     where diff a b = floor ((a - b) * 1000) -- as millis
           d = asFrac jds jdu
@@ -150,17 +154,22 @@ timeDiff (ds, du) (s, u) = diff d i
 
 
 -- MIDI Utils
+encodeChannel :: (Bits a, Num a) => a -> a -> a
 encodeChannel ch cc = (((-) ch 1) .|. cc)
 
+
 -- MIDI Messages
+noteOn :: Output -> CLong -> CLong -> CLong -> CULong -> IO (Maybe a)
 noteOn o ch val vel t = do
   let evt = makeEvent 0x90 val ch vel t
   sendEvent o evt
 
+noteOff :: Output -> CLong -> CLong -> CULong -> IO (Maybe a)
 noteOff o ch val t = do
   let evt = makeEvent 0x80 val ch 60 t
   sendEvent o evt
 
+makeCtrl :: Output -> CLong -> C.Param -> Float -> CULong -> IO (Maybe a)
 makeCtrl o ch (C.CC {C.midi=midi, C.range=range, C.scalef=f}) n t = makeCC o ch (fromIntegral midi) scaledN t
   where scaledN = fromIntegral (f range (n))
 makeCtrl o ch (C.NRPN {C.midi=midi, C.range=range, C.scalef=f}) n t = makeNRPN o ch (fromIntegral midi) scaledN t
@@ -168,13 +177,14 @@ makeCtrl o ch (C.NRPN {C.midi=midi, C.range=range, C.scalef=f}) n t = makeNRPN o
 makeCtrl o ch (C.SysEx {C.midi=midi, C.range=range, C.scalef=f}) n t = makeSysEx o ch (fromIntegral midi) scaledN t
   where scaledN = fromIntegral $ (f range (n))
 
-
 -- This is sending CC
+makeCC :: Output -> CLong -> CLong -> CLong -> CULong -> IO (Maybe a)
 makeCC o ch c n t = do
   let evt = makeEvent 0xB0 c ch n t
   sendEvent o evt
 
 -- This is sending NRPN
+makeNRPN :: Output -> CLong -> CLong -> CLong -> CULong -> IO (Maybe a)
 makeNRPN o ch c n t = do
   let nrpn = makeEvent 0xB0
       evts = [nrpn 0x63 ch (shift (c .&. 0x3F80) (-7)) t,
@@ -188,6 +198,7 @@ makeNRPN o ch c n t = do
 makeMidiClockTick o t = do
   sendEvent o $ PM.PMEvent (PM.PMMsg 0xF8 0x00 0x00) t
 
+makeSysEx :: Output -> t -> Word8 -> Word8 -> CULong -> IO (Maybe a)
 makeSysEx o ch c n t = do
   let bytes = [0xF0, -- SysEx Start
                0x3E, -- Vendor ID
@@ -207,6 +218,7 @@ makeSysEx o ch c n t = do
 
 -- PortMIDI Wrapper
 
+outputDevice :: PM.DeviceID -> Int -> IO (Either Output PM.PMError)
 outputDevice deviceID latency = do
   PM.initialize
   now <- getCurrentTime
@@ -229,9 +241,11 @@ outputDevice deviceID latency = do
         return (Left Output { conn=dev, lock=sem, offset=(sec, usec), buffer=buffer })
     Right err -> return (Right err)
 
+makeEvent :: CLong -> CLong -> CLong -> CLong -> CULong -> PM.PMEvent
 makeEvent st n ch v t = PM.PMEvent msg (t)
   where msg = PM.PMMsg (encodeChannel ch st) (n) (v)
 
+sendSysEx :: Output -> CULong -> String -> IO (Maybe a)
 sendSysEx o t msg = do
   let sem = lock o
   takeMVar sem
@@ -240,6 +254,7 @@ sendSysEx o t msg = do
   return Nothing
 
 -- now with a semaphore since PortMIDI is NOT thread safe
+sendEvent :: Output -> PM.PMEvent -> IO (Maybe a)
 sendEvent o evt = do
   let sem = lock o
       buf = buffer o

--- a/Sound/Tidal/Rytm.hs
+++ b/Sound/Tidal/Rytm.hs
@@ -1,0 +1,203 @@
+module Sound.Tidal.Rytm where
+
+import Sound.Tidal.Stream (makeI, makeF)
+
+import Sound.Tidal.MIDI.Control
+
+keys :: ControllerShape
+keys = ControllerShape { params = [
+
+                            mCC "synth1" 16,
+                            mCC "synth2" 17,
+                            mCC "synth3" 18,
+                            mCC "synth4" 19,
+                            mCC "synth5" 20,
+                            mCC "synth6" 21,
+                            mCC "synth7" 22,
+                            mCC "synth8" 23,
+
+                            mCC "revpre" 24,
+                            mCC "revtime" 25,
+                            mCC "revfrq" 26,
+                            mCC "revgain" 27,
+                            mCC "revhpf" 28,
+                            mCC "revlpf" 29,
+                            mCC "revvol" 31,
+
+                            mCC "samptune" 24,
+                            mCC "sampfinetune" 25,
+                            mCC "sampbitreduction" 26,
+                            mCC "sampslot" 27,
+                            mCC "sampstart" 28,
+                            mCC "sampend" 29,
+                            mCC "samploop" 30,
+                            mCC "samplevel" 31,
+
+                            mCC "machtype" 15,
+
+                            mCC "filtatk" 70,
+                            mCC "filtdec" 71,
+                            mCC "filtsus" 72,
+                            mCC "filtrel" 73,
+                            mCC "filtfrq" 74,
+                            mCC "filtres" 75,
+                            mCC "filttyp" 76,
+                            mCC "filtenv" 77,
+
+                            mCC "perf1" 35,
+                            mCC "perf2" 36,
+                            mCC "perf3" 37,
+                            mCC "perf4" 39,
+                            mCC "perf5" 40,
+                            mCC "perf6" 41,
+                            mCC "perf7" 42,
+                            mCC "perf8" 43,
+
+                            mCC "atk" 78,
+                            mCC "hld" 79,
+                            mCC "dec" 80,
+                            mCC "ovr" 81,
+                            mCC "del" 82,
+                            mCC "amprev" 83,
+                            mCC "amppan" 10,
+                            mCC "vol" 7
+                          ],
+                         duration = ("dur", 0.05),
+                         velocity = ("vel", 0.5),
+                         latency = 0.1
+                       }
+
+oscKeys = toOscShape keys
+
+-- note on/off
+note         = makeI oscKeys "note"
+dur          = makeF oscKeys "dur"
+
+-- standard synth params
+synth1       = makeF oscKeys "synth1"
+synth2       = makeF oscKeys "synth2"
+synth3       = makeF oscKeys "synth3"
+synth4       = makeF oscKeys "synth4"
+synth5       = makeF oscKeys "synth5"
+synth6       = makeF oscKeys "synth6"
+synth7       = makeF oscKeys "synth7"
+synth8       = makeF oscKeys "synth8"
+
+-- machine type (e.g. hard snare, classic snare, hard bd, classic bd, etc)
+machtype     = makeF oscKeys "machtype"
+
+-- generic synth level and tuning
+lev          = makeF oscKeys "synth1"
+tun          = makeF oscKeys "synth2"
+
+-- generic bd decay and sweep type
+bddec        = makeF oscKeys "synth3"
+bdswt        = makeF oscKeys "synth5"
+
+-- FM bd params
+fmbdfmamt    = makeF oscKeys "synth4"
+fmbdfmswt    = makeF oscKeys "synth6"
+fmbdfmdec    = makeF oscKeys "synth7"
+fmbdfmtun    = makeF oscKeys "synth8"
+
+-- hard bd params
+hardbdhold   = makeF oscKeys "synth4"
+hardbdsnap   = makeF oscKeys "synth6"
+hardbdwav    = makeF oscKeys "synth7"
+hardbdtic    = makeF oscKeys "synth8"
+
+-- classic bd params
+clasbdswd    = makeF oscKeys "synth6"
+clasbdtra    = makeF oscKeys "synth7"
+clasbdwav    = makeF oscKeys "synth8"
+
+-- generic sd params (decay, noise decay, noise level)
+sddec        = makeF oscKeys "synth3"
+sdnod        = makeF oscKeys "synth6"
+sdnol        = makeF oscKeys "synth7"
+
+-- hard sd params
+hardsdswd    = makeF oscKeys "synth4"
+hardsdtic    = makeF oscKeys "synth5"
+hardsdswt    = makeF oscKeys "synth8"
+
+-- classic sd params
+classddet    = makeF oscKeys "synth4"
+classdsnp    = makeF oscKeys "synth5"
+classdbal    = makeF oscKeys "synth8"
+
+-- FM sd params
+fmsdfmt      = makeF oscKeys "synth4"
+fmsdfmd      = makeF oscKeys "synth5"
+fmsdfma      = makeF oscKeys "synth8"
+
+-- BT
+btdec        = makeF oscKeys "synth3"
+
+-- CP
+cpton        = makeF oscKeys "synth2"
+cpnod        = makeF oscKeys "synth3"
+cpnum        = makeF oscKeys "synth4"
+cprat        = makeF oscKeys "synth5"
+cpnol        = makeF oscKeys "synth6"
+cprnd        = makeF oscKeys "synth7"
+cpcpd        = makeF oscKeys "synth8"
+
+-- filter params
+filtatk      = makeF oscKeys "filtatk"
+filtdec      = makeF oscKeys "filtdec"
+filtsus      = makeF oscKeys "filtsus"
+filtrel      = makeF oscKeys "filtrel"
+filtfrq      = makeF oscKeys "filtfrq"
+filtres      = makeF oscKeys "filtres"
+filttyp      = makeF oscKeys "filttyp"
+filtenv      = makeF oscKeys "filtenv"
+
+-- amplitude params
+atk          = makeF oscKeys "atk"
+hld          = makeF oscKeys "hld"
+dec          = makeF oscKeys "dec"
+ovr          = makeF oscKeys "ovr"
+del          = makeF oscKeys "del"
+amprev       = makeF oscKeys "amprev"
+amppan       = makeF oscKeys "amppan"
+vol          = makeF oscKeys "vol"
+
+-- delay params (only used on FX MIDI channel)
+deltime      = makeF oscKeys "synth1"
+delpingpong  = makeF oscKeys "synth2"
+delwidth     = makeF oscKeys "synth3"
+delfeedback  = makeF oscKeys "synth4"
+delhpf       = makeF oscKeys "synth5"
+dellpf       = makeF oscKeys "synth6"
+delrev       = makeF oscKeys "synth7"
+delvol       = makeF oscKeys "synth8"
+
+-- reverb params (only used on FX MIDI channel)
+revpre       = makeF oscKeys "revpre"
+revtime      = makeF oscKeys "revtime"
+revfrq       = makeF oscKeys "revfrq"
+revgain      = makeF oscKeys "revgain"
+revhpf       = makeF oscKeys "revhpf"
+revlpf       = makeF oscKeys "revlpf"
+revvol       = makeF oscKeys "revvol"
+
+-- performance
+perf1        = makeF oscKeys "perf1"
+perf2        = makeF oscKeys "perf2"
+perf3        = makeF oscKeys "perf3"
+perf4        = makeF oscKeys "perf4"
+perf5        = makeF oscKeys "perf5"
+perf6        = makeF oscKeys "perf6"
+perf7        = makeF oscKeys "perf7"
+perf8        = makeF oscKeys "perf8"
+
+-- sample
+samptune         = makeF oscKeys "samptune"
+sampfinetune     = makeF oscKeys "sampfinetune"
+sampbitreduction = makeF oscKeys "sampbitreduction"
+sampslot         = makeF oscKeys "sampslot"
+sampstart        = makeF oscKeys "sampstart"
+sampend          = makeF oscKeys "sampend"
+samploop         = makeF oscKeys "samploop"
+samplevel        = makeF oscKeys "samplevel"

--- a/Sound/Tidal/SimpleSynth.hs
+++ b/Sound/Tidal/SimpleSynth.hs
@@ -1,0 +1,26 @@
+module Sound.Tidal.SimpleSynth where
+
+import Sound.Tidal.Stream (makeI, makeF)
+
+import Sound.Tidal.MIDI.Control
+
+keys :: ControllerShape
+keys = ControllerShape {params = [
+                          mCC "modwheel" 1,
+                          mCC "balance" 10,
+                          mCC "expression" 11,
+                          mCC "sustainpedal" 64
+                        ],
+                        duration = ("dur", 0.05),
+                        velocity = ("vel", 0.5),
+                        latency = 0.1}
+
+oscKeys = toOscShape keys
+
+note         = makeI oscKeys "note"
+dur          = makeF oscKeys "dur"
+vel          = makeF oscKeys "vel"
+modwheel     = makeF oscKeys "modwheel"
+balance          = makeF oscKeys "balance"
+expression   = makeF oscKeys "expression"
+sustainpedal = makeF oscKeys "sustainpedal"

--- a/Sound/Tidal/Synthino.hs
+++ b/Sound/Tidal/Synthino.hs
@@ -1,0 +1,52 @@
+module Sound.Tidal.Synthino where
+
+import Sound.Tidal.Stream (makeI, makeF)
+
+import Sound.Tidal.MIDI.Control
+
+keys :: ControllerShape
+keys = ControllerShape { params = [
+                            mCC "attack" 73,
+                            mCC "decay" 75,
+                            mCC "sustain" 79,
+                            mCC "release" 72,
+                            mCC "waveform" 70,
+                            mCC "pitchlforate" 76,
+                            mCC "pitchlfodepth" 1,
+                            mCC "lfowaveform" 12,
+                            mCC "filterlforate" 13,
+                            mCC "filterlfodepth" 91,
+                            mCC "peak" 71,
+                            mCC "kcutoff" 74,
+                            mCC "bpm" 16,
+                            mCC "arplength" 17,
+                            mCC "arptranspose" 18,
+                            mCC "vol" 7,
+                            mCC "off" 123
+                          ],
+                         duration = ("dur", 0.05),
+                         velocity = ("vel", 0.5),
+                         latency = 0.1
+                       }
+
+oscKeys = toOscShape keys
+
+note           = makeI oscKeys "note"
+dur            = makeF oscKeys "dur"
+attack         = makeF oscKeys "attack"
+decay          = makeF oscKeys "decay"
+sustain        = makeF oscKeys "sustain"
+release        = makeF oscKeys "release"
+waveform       = makeF oscKeys "waveform"
+pitchlforate   = makeF oscKeys "pitchlforate"
+pitchlfodepth  = makeF oscKeys "pitchlfodepth"
+lfowaveform    = makeF oscKeys "lfowaveform"
+filterlforate  = makeF oscKeys "filterlforate"
+filterlfodepth = makeF oscKeys "filterlfodepth"
+peak           = makeF oscKeys "peak"
+kcutoff        = makeF oscKeys "kcutoff"
+bpm            = makeF oscKeys "bpm"
+arplength     = makeF oscKeys "arplength"
+arptranspose      = makeF oscKeys "arptranspose"
+vol            = makeF oscKeys "vol"
+off            = makeF oscKeys "off"

--- a/Sound/Tidal/Tetra.hs
+++ b/Sound/Tidal/Tetra.hs
@@ -1,0 +1,530 @@
+module Sound.Tidal.Tetra where
+
+import Sound.Tidal.Stream (makeI, makeF, (|+|), merge, OscPattern)
+
+import Sound.Tidal.MIDI.Control
+
+import Sound.Tidal.Parse
+import Sound.Tidal.Pattern
+
+import Control.Applicative
+
+makeSeqTracks = concat $ map makeSeqTrack [0..3]
+  where makeSeqTrack t = map (makeSeqStep t) [0..15]
+        makeSeqStep t s = NRPN (makeName t s) (makeCC t s) (0, 127) 0 passThru
+        makeName t s = "seq" ++ (show $ t + 1) ++ "step" ++ (show $ s + 1)
+        makeCC t s = (t * 16) + (s + 120)
+
+polysynth :: ControllerShape
+polysynth = ControllerShape { params = ([
+                                  mrNRPN "osc1freq" 0 (0, 120) 0.2,
+                                  mrNRPN "osc1detune" 1 (0, 100) 0.5,
+                                  NRPN "osc1shape" 2 (0, 103) 1 passThru,
+                                  mNRPN "osc1glide" 3,
+                                  NRPN "osc1kbd" 4 (0, 1) 1 passThru,
+
+                                  mrNRPN "osc2freq" 5 (0, 120) 0.2,
+                                  mrNRPN "osc2detune" 6 (0, 100) 0.5,
+                                  NRPN "osc2shape" 7 (0, 103) 1 passThru,
+                                  mNRPN "osc2glide" 8,
+                                  NRPN "osc2kbd" 9 (0, 1) 1 passThru,
+
+                                  NRPN "oscsync" 10 (0, 1) 0 passThru,
+                                  NRPN "glidemode" 11 (0, 3) 0 passThru,
+                                  NRPN "oscslop" 12 (0, 5) 0 passThru,
+                                  mrNRPN "oscmix" 13 (0, 127) 0.5,
+
+                                  mNRPN "noise" 14,
+                                  mrNRPN "kcutoff" 15 (0, 164) 1,
+                                  mNRPN "kresonance" 16,
+                                  mNRPN "kamt" 17,
+                                  mNRPN "audiomod" 18,
+                                  NRPN "fpoles" 19 (0, 1) 1 passThru,
+
+                                  -- filter envelope
+                                  mrNRPN "famt" 20 (0, 254) 0.5,
+                                  mNRPN "fvel" 21,
+                                  mNRPN "fdel" 22,
+                                  mNRPN "fatk" 23,
+                                  mNRPN "fdcy" 24,
+                                  mNRPN "fsus" 25,
+                                  mNRPN "frel" 26,
+
+
+                                  mNRPN "vcavol" 27,
+                                  mNRPN "outspread" 28,
+                                  mrNRPN "vol" 29 (0, 127) 1, -- max volume by default
+
+                                  mrNRPN "vamt" 30 (0, 127) 1, -- max vca envelope amount
+                                  mNRPN "vvel" 31,
+                                  mNRPN "vdel" 32,
+                                  mNRPN "vatk" 33,
+                                  mrNRPN "vdcy" 34 (0, 127) 0.5,
+                                  mrNRPN "vsus" 35 (0, 127) 0.5,
+                                  mNRPN "vrel" 36,
+
+                                  NRPN "lfo1rate" 37 (0, 166) 0 passThru, -- unsynced
+                                  -- mrNRPN "lfo1step" 37 (151, 166) 0, -- (bpm / 32) - 16 bpm-cycles
+                                  NRPN "lfo1shape" 38 (0, 4) 0 passThru,
+                                  mNRPN "lfo1amt" 39,
+                                  NRPN "lfo1dest" 40 (0, 43) 0 passThru,
+                                  NRPN "lfo1sync" 41 (0, 1) 0 passThru,
+
+                                  NRPN "lfo2rate" 42 (0, 166) 0 passThru, -- unsynced
+                                  -- mrNRPN "lfo2step" 42 (151, 166) 0, -- (bpm / 32) - 16 bpm-cycles
+                                  NRPN "lfo2shape" 43 (0, 4) 0 passThru,
+                                  mNRPN "lfo2amt" 44,
+                                  NRPN "lfo2dest" 45 (0, 43) 0 passThru,
+                                  NRPN "lfo2sync" 46 (0, 1) 0 passThru,
+
+                                  NRPN "lfo3rate" 47 (0, 166) 0 passThru, -- unsynced
+                                  -- mrNRPN "lfo3step" 47 (151, 166) 0, -- (bpm / 32) - 16 bpm-cycles
+                                  NRPN "lfo3shape" 48 (0, 4) 0 passThru,
+                                  mNRPN "lfo3amt" 49,
+                                  NRPN "lfo3dest" 50 (0, 43) 0 passThru,
+                                  NRPN "lfo3sync" 51 (0, 1) 0 passThru,
+
+                                  NRPN "lfo4rate" 52 (0, 166) 0 passThru, -- unsynced
+                                  -- mrNRPN "lfo4step" 52 (151, 166) 0, -- (bpm / 32) - 16 bpm-cycles
+                                  NRPN "lfo4shape" 53 (0, 4) 0 passThru,
+                                  mNRPN "lfo4amt" 54,
+                                  NRPN "lfo4dest" 55 (0, 43) 0 passThru,
+                                  NRPN "lfo4sync" 56 (0, 1) 0 passThru,
+
+                                  NRPN "emod" 57 (0, 43) 0 passThru,
+                                  mrNRPN "eamt" 58 (0, 254) 0.5,
+                                  mNRPN "evel" 59,
+                                  mNRPN "edel" 60,
+                                  mNRPN "eatk" 61,
+                                  mNRPN "edcy" 62,
+                                  mNRPN "esus" 63,
+                                  mNRPN "erel" 64,
+
+                                  NRPN "mod1src" 65 (0, 20) 0 passThru,
+                                  mrNRPN "mod1amt" 66 (0, 254) 0.5,
+                                  NRPN "mod1dst" 67 (0, 47) 0 passThru,
+
+                                  NRPN "mod2src" 68 (0, 20) 0 passThru,
+                                  mrNRPN "mod2amt" 69 (0, 254) 0.5,
+                                  NRPN "mod2dst" 70 (0, 47) 0 passThru,
+
+                                  NRPN "mod3src" 71 (0, 20) 0 passThru,
+                                  mrNRPN "mod3amt" 72 (0, 254) 0.5,
+                                  NRPN "mod3dst" 73 (0, 47) 0 passThru,
+
+                                  NRPN "mod4src" 74 (0, 20) 0 passThru,
+                                  mrNRPN "mod4amt" 75 (0, 254) 0.5,
+                                  NRPN "mod4dst" 76 (0, 47) 0 passThru,
+
+                                  NRPN "seq1dst" 77 (0, 47) 0 passThru,
+                                  NRPN "seq2dst" 78 (0, 47) 0 passThru,
+                                  NRPN "seq3dst" 79 (0, 47) 0 passThru,
+                                  NRPN "seq4dst" 80 (0, 47) 0 passThru,
+
+                                  mrNRPN "mwhl" 81 (0, 254) 0.5,
+                                  NRPN "mwhldst" 82 (0, 47) 0 passThru,
+
+                                  mrNRPN "aftt" 83 (0, 254) 0.5,
+                                  NRPN "afttdst" 84 (0, 47) 0 passThru,
+
+                                  mrNRPN "breath" 85 (0, 254) 0.5,
+                                  NRPN "breathdst" 86 (0, 47) 0 passThru,
+
+                                  mrNRPN "mvel" 87 (0, 254) 0.5,
+                                  NRPN "mveldst" 88 (0, 47) 0 passThru,
+
+                                  mrNRPN "foot" 89 (0, 254) 0.5,
+                                  NRPN "footdst" 90 (0, 47) 0 passThru,
+
+                                  NRPN "kbpm" 91 (30, 250) 0 passThru,
+                                  NRPN "clockdiv" 92 (0, 12) 0 passThru, -- TODO: document values
+
+                                  NRPN "bendrng" 93 (0, 12) 0 passThru,
+
+                                  NRPN "sqntrig" 94 (0, 4) 0 passThru, -- TODO: document values
+                                  NRPN "unisonkey" 95 (0, 5) 0 passThru, -- TODO: document values
+                                  NRPN "unisonmode" 96 (0, 4) 0 passThru, -- TODO: document values
+                                  NRPN "arpmode" 97 (0, 14) 0 passThru,
+
+                                  NRPN "erepeat" 98 (0, 1) 0 passThru,
+                                  NRPN "unison" 99 (0, 1) 0 passThru,
+
+
+                                  NRPN "arp" 100 (0, 1) 0 passThru,
+                                  NRPN "sqn" 101 (0, 1) 0 passThru,
+
+                                  NRPN "mcr1" 105 (0, 183) 0 passThru,
+                                  NRPN "mcr2" 106 (0, 183) 0 passThru,
+                                  NRPN "mcr3" 107 (0, 183) 0 passThru,
+                                  NRPN "mcr4" 108 (0, 183) 0 passThru,
+
+                                  mNRPN "fbgain" 110,
+
+                                  mrNRPN "btnfreq" 111 (0, 127) 0.25,
+                                  mrNRPN "btnvel" 112 (0, 127) 1,
+                                  NRPN "btnmode" 113 (0, 1) 0 passThru,
+
+                                  mNRPN "sub1vol" 114,
+                                  mNRPN "sub2vol" 115,
+
+                                  mNRPN "fbvol" 116,
+
+                                  -- left out: editor byte,
+
+                                  mrNRPN "ksplitpoint" 118 (0, 127) 0.5,
+                                  NRPN "kmode" 119 (0, 2) 0 passThru, -- TODO: document values
+                                  mCC "notesoff" 123,
+                                  mCC "ccreset" 121,
+                                  mCC "damp" 64
+
+                          ] ++ makeSeqTracks),
+                         duration = ("dur", 0.2),
+                         velocity = ("vel", 0.5),
+                         latency = 0.04
+                       }
+
+oscPolysynth = toOscShape polysynth
+
+note            = makeI oscPolysynth "note"
+
+dur             = makeF oscPolysynth "dur"
+vel             = makeF oscPolysynth "vel"
+notesoff = makeF oscPolysynth "notesoff"
+ccreset = makeF oscPolysynth "ccreset"
+damp = makeF oscPolysynth "damp"
+
+
+osc1freq      = makeF oscPolysynth "osc1freq"
+osc1detune      = makeF oscPolysynth "osc1detune"
+osc1shape     = makeF oscPolysynth "osc1shape"
+osc1glide     = makeF oscPolysynth "osc1glide"
+osc1kbd     = makeF oscPolysynth "osc1kbd"
+
+osc2freq      = makeF oscPolysynth "osc2freq"
+osc2detune      = makeF oscPolysynth "osc2detune"
+osc2shape     = makeF oscPolysynth "osc2shape"
+osc2glide     = makeF oscPolysynth "osc2glide"
+osc2kbd     = makeF oscPolysynth "osc2kbd"
+
+oscsync     = makeF oscPolysynth "oscsync"
+glidemode     = makeF oscPolysynth "glidemode"
+oscslop     = makeF oscPolysynth "oscslop"
+oscmix      = makeF oscPolysynth "oscmix"
+
+noise     = makeF oscPolysynth "noise"
+kcutoff     = makeF oscPolysynth "kcutoff"
+kresonance      = makeF oscPolysynth "kresonance"
+kamt      = makeF oscPolysynth "kamt"
+audiomod      = makeF oscPolysynth "audiomod"
+fpoles      = makeF oscPolysynth "fpoles"
+twopole         = fpoles (p "0")
+fourpole        = fpoles (p "1")
+
+-- filter envelope
+famt      = makeF oscPolysynth "famt"
+fvel      = makeF oscPolysynth "fvel"
+fdel      = makeF oscPolysynth "fdel"
+fatk      = makeF oscPolysynth "fatk"
+fdcy      = makeF oscPolysynth "fdcy"
+fsus      = makeF oscPolysynth "fsus"
+frel      = makeF oscPolysynth "frel"
+
+
+vcavol      = makeF oscPolysynth "vcavol"
+outspread     = makeF oscPolysynth "outspread"
+vol     = makeF oscPolysynth "vol"
+
+vamt      = makeF oscPolysynth "vamt"
+vvel      = makeF oscPolysynth "vvel"
+vdel      = makeF oscPolysynth "vdel"
+vatk      = makeF oscPolysynth "vatk"
+vdcy      = makeF oscPolysynth "vdcy"
+vsus      = makeF oscPolysynth "vsus"
+vrel      = makeF oscPolysynth "vrel"
+
+lfo1rate      = makeF oscPolysynth "lfo1rate"
+-- lfo1step      = makeF oscPolysynth "lfo1step"
+lfo1shape     = makeF oscPolysynth "lfo1shape"
+lfo1amt     = makeF oscPolysynth "lfo1amt"
+lfo1dest      = makeF oscPolysynth "lfo1dest"
+lfo1sync      = makeF oscPolysynth "lfo1sync"
+
+lfo2rate      = makeF oscPolysynth "lfo2rate"
+-- lfo2step      = makeF oscPolysynth "lfo2step"
+lfo2shape     = makeF oscPolysynth "lfo2shape"
+lfo2amt     = makeF oscPolysynth "lfo2amt"
+lfo2dest      = makeF oscPolysynth "lfo2dest"
+lfo2sync      = makeF oscPolysynth "lfo2sync"
+
+lfo3rate      = makeF oscPolysynth "lfo3rate"
+-- lfo3step      = makeF oscPolysynth "lfo3step"
+lfo3shape     = makeF oscPolysynth "lfo3shape"
+lfo3amt     = makeF oscPolysynth "lfo3amt"
+lfo3dest      = makeF oscPolysynth "lfo3dest"
+lfo3sync      = makeF oscPolysynth "lfo3sync"
+
+lfo4rate      = makeF oscPolysynth "lfo4rate"
+-- lfo4step      = makeF oscPolysynth "lfo4step"
+lfo4shape     = makeF oscPolysynth "lfo4shape"
+lfo4amt     = makeF oscPolysynth "lfo4amt"
+lfo4dest      = makeF oscPolysynth "lfo4dest"
+lfo4sync      = makeF oscPolysynth "lfo4sync"
+
+emod      = makeF oscPolysynth "emod"
+eamt      = makeF oscPolysynth "eamt"
+evel      = makeF oscPolysynth "evel"
+edel      = makeF oscPolysynth "edel"
+eatk      = makeF oscPolysynth "eatk"
+edcy      = makeF oscPolysynth "edcy"
+esus      = makeF oscPolysynth "esus"
+erel      = makeF oscPolysynth "erel"
+
+mod1src     = makeF oscPolysynth "mod1src"
+mod1amt     = makeF oscPolysynth "mod1amt"
+mod1dst     = makeF oscPolysynth "mod1dst"
+
+mod2src     = makeF oscPolysynth "mod2src"
+mod2amt     = makeF oscPolysynth "mod2amt"
+mod2dst     = makeF oscPolysynth "mod2dst"
+
+mod3src     = makeF oscPolysynth "mod3src"
+mod3amt     = makeF oscPolysynth "mod3amt"
+mod3dst     = makeF oscPolysynth "mod3dst"
+
+mod4src     = makeF oscPolysynth "mod4src"
+mod4amt     = makeF oscPolysynth "mod4amt"
+mod4dst     = makeF oscPolysynth "mod4dst"
+
+seq1dst     = makeF oscPolysynth "seq1dst"
+seq2dst     = makeF oscPolysynth "seq2dst"
+seq3dst     = makeF oscPolysynth "seq3dst"
+seq4dst     = makeF oscPolysynth "seq4dst"
+
+
+mwhl    = makeF oscPolysynth "mwhl"
+mwhldst = makeF oscPolysynth "mwhldst"
+
+aftt    = makeF oscPolysynth "aftt"
+afttdst = makeF oscPolysynth "afttdst"
+
+breath    = makeF oscPolysynth "breath"
+breathdst = makeF oscPolysynth "breathdst"
+
+mvel    = makeF oscPolysynth "mvel"
+mveldst = makeF oscPolysynth "mveldst"
+
+foot    = makeF oscPolysynth "foot"
+footdst = makeF oscPolysynth "footdst"
+
+bendrng = makeF oscPolysynth "bendrng"
+
+-- left out: modwheel, breath, footctrl, pressure, velocity
+
+kbpm      = makeF oscPolysynth "kbpm"
+clockdiv      = makeF oscPolysynth "clockdiv"
+
+-- left out: pitchbend range
+
+sqntrig     = makeF oscPolysynth "sqntrig"
+unisonkey     = makeF oscPolysynth "unisonkey"
+unisonmode      = makeF oscPolysynth "unisonmode"
+arpmode     = makeF oscPolysynth "arpmode"
+
+erepeat     = makeF oscPolysynth "erepeat"
+unison      = makeF oscPolysynth "unison"
+
+
+arp     = makeF oscPolysynth "arp"
+sqn     = makeF oscPolysynth "sqn"
+
+mcr1      = makeF oscPolysynth "mcr1"
+mcr2      = makeF oscPolysynth "mcr2"
+mcr3      = makeF oscPolysynth "mcr3"
+mcr4      = makeF oscPolysynth "mcr4"
+
+fbgain      = makeF oscPolysynth "fbgain"
+
+btnfreq     = makeF oscPolysynth "btnfreq"
+btnvel      = makeF oscPolysynth "btnvel"
+btnmode     = makeF oscPolysynth "btnmode"
+
+sub1vol     = makeF oscPolysynth "sub1vol"
+sub2vol     = makeF oscPolysynth "sub2vol"
+
+fbvol     = makeF oscPolysynth "fbvol"
+
+ksplitpoint     = makeF oscPolysynth "ksplitpoint"
+kmode     = makeF oscPolysynth "kmode"
+knormal         = kmode (p "0")
+kstack          = kmode (p "0.5")
+ksplit          = kmode (p "1")
+
+-- sequences
+
+seqtrack1 = map (makeF oscPolysynth . (\x -> "seq1step" ++ show x)) [1..16]
+seqtrack2 = map (makeF oscPolysynth . (\x -> "seq2step" ++ show x)) [1..16]
+seqtrack3 = map (makeF oscPolysynth . (\x -> "seq3step" ++ show x)) [1..16]
+seqtrack4 = map (makeF oscPolysynth . (\x -> "seq4step" ++ show x)) [1..16]
+
+
+seqpatterns p' = map onlyValues events
+  where arc' = arc p'
+        events = arc' (0,1)
+        onlyValues = \(_, _, a) -> p a
+
+sqnp i t p' = foldr (|+|) i (zipWith ($) t patterns)
+  where patterns = seqpatterns p'
+
+sqnp1 d p' = sqnp (seq1dst $ p $ show d) seqtrack1 p'
+sqnp2 d p' = sqnp (seq2dst $ p $ show d) seqtrack2 p'
+sqnp3 d p' = sqnp (seq3dst $ p $ show d) seqtrack3 p'
+sqnp4 d p' = sqnp (seq4dst $ p $ show d) seqtrack4 p'
+
+
+-- abstractions
+
+-- adsr
+
+atk p' = vatk p' |+| fatk p' |+| eatk p'
+dcy p' = vdcy p' |+| fdcy p' |+| edcy p'
+sus p' = vsus p' |+| fsus p' |+| esus p'
+rel p' = vrel p' |+| frel p' |+| erel p'
+
+adsr a d s r = atk a |+| dcy d |+| sus s |+| rel r
+asr a d r = atk a |+| dcy d |+| rel r
+
+-- lfo
+
+lfotri = doublePattern 0
+lforsaw = doublePattern 1
+lfosaw = doublePattern 2
+lfopulse = doublePattern 3
+lforand = doublePattern 4
+
+lrate r = ((min 150) . (max 0)) <$> p r
+lstep s = ((min 166) . (max 151) . (+150)) <$> p s
+
+lfo1 s d r a = lfo1shape s |+| lfo1dest d |+| lfo1rate r |+| lfo1amt a
+lfo2 s d r a = lfo2shape s |+| lfo2dest d |+| lfo2rate r |+| lfo2amt a
+lfo3 s d r a = lfo3shape s |+| lfo3dest d |+| lfo3rate r |+| lfo3amt a
+lfo4 s d r a = lfo4shape s |+| lfo4dest d |+| lfo4rate r |+| lfo4amt a
+
+--lfo = lfo1
+
+-- mod
+
+mod1 s d a = mod1src s |+| mod1dst d |+| mod1amt a
+mod2 s d a = mod2src s |+| mod2dst d |+| mod2amt a
+mod3 s d a = mod3src s |+| mod3dst d |+| mod3amt a
+mod4 s d a = mod4src s |+| mod4dst d |+| mod4amt a
+
+-- mod destination
+
+doublePattern d = (p $ show d) :: Pattern Double
+
+dosc1 = doublePattern 1
+dosc2 = doublePattern 2
+dosc = doublePattern 3
+dmix = doublePattern 4
+dnoise = doublePattern 5
+dpw1 = doublePattern 6
+dpw2 = doublePattern 7
+dpw = doublePattern 8
+dcut = doublePattern 9
+dres = doublePattern 10
+damod = doublePattern 11
+dvca = doublePattern 12
+dspread = doublePattern 13
+
+dlfo1f = doublePattern 14
+dlfo2f = doublePattern 15
+dlfo3f = doublePattern 16
+dlfo4f = doublePattern 17
+dlfof = doublePattern 18
+
+dlfo1a = doublePattern 19
+dlfo2a = doublePattern 20
+dlfo3a = doublePattern 21
+dlfo4a = doublePattern 22
+dlfoa = doublePattern 23
+
+dfamt = doublePattern 24
+dvamt = doublePattern 25
+deamt = doublePattern 26
+damt = doublePattern 27
+
+dfatk = doublePattern 28
+dvatk = doublePattern 29
+deatk = doublePattern 30
+datk = doublePattern 31
+
+dfdcy = doublePattern 32
+dvdcy = doublePattern 33
+dedcy = doublePattern 34
+ddcy = doublePattern 35
+
+dfrel = doublePattern 36
+dvrel = doublePattern 37
+derel = doublePattern 38
+drel = doublePattern 39
+
+dmod1 = doublePattern 40
+dmod2 = doublePattern 41
+dmod3 = doublePattern 42
+dmod4 = doublePattern 43
+
+dfb = doublePattern 44
+dsub1 = doublePattern 45
+dsub2 = doublePattern 46
+dfbgain = doublePattern 47
+dslew = doublePattern 48
+
+-- mod sources
+
+sseq1 = doublePattern 1
+sseq2 = doublePattern 2
+sseq3 = doublePattern 3
+sseq4 = doublePattern 4
+
+slfo1 = doublePattern 5
+slfo2 = doublePattern 6
+slfo3 = doublePattern 7
+slfo4 = doublePattern 8
+
+sfenv = doublePattern 9
+svenv = doublePattern 10
+seenv = doublePattern 11
+
+spitchb = doublePattern 12
+smodwh = doublePattern 13
+saftert = doublePattern 14
+sbreath = doublePattern 15
+sfoot = doublePattern 16
+sexpr = doublePattern 17
+
+svel = doublePattern 18
+snote = doublePattern 19
+snoise = doublePattern 20
+-- drums
+
+
+snare d p' = note p'
+  |+| osc1shape zero |+| osc1kbd zero
+  |+| osc2shape zero |+| osc2kbd zero
+  |+| noise one
+  |+| vrel d |+| vsus zero |+| vdcy d
+  |+| kcutoff (p "1")
+  |+| dur (p "0.01")
+  where zero = p "0"
+        one = p "1"
+
+
+kick blp p' = note p'
+  |+| fourpole
+  |+| osc1shape zero |+| osc1kbd zero
+  |+| osc2shape zero |+| osc2kbd zero
+  |+| vsus zero |+| vdcy (p "0.95") |+| vrel (p "0.5")
+  |+| kresonance (p "0.99") |+| kcutoff zero
+  |+| eamt (p "0.8") |+| emod (p "9") |+| edcy blp
+  |+| dur (p "0.2")
+  where zero = p "0"

--- a/Sound/Tidal/VolcaBass.hs
+++ b/Sound/Tidal/VolcaBass.hs
@@ -1,142 +1,42 @@
-  
 module Sound.Tidal.VolcaBass where
 
-import qualified Sound.ALSA.Sequencer.Address as Addr
-import qualified Sound.ALSA.Sequencer.Client as Client
-import qualified Sound.ALSA.Sequencer.Port as Port
-import qualified Sound.ALSA.Sequencer.Event as Event
-import qualified Sound.ALSA.Sequencer as SndSeq
-import qualified Sound.ALSA.Exception as AlsaExc
-import qualified Sound.ALSA.Sequencer.Connect as Connect
-import GHC.Word
-import GHC.Int
+import Sound.Tidal.Stream (makeI, makeF)
 
-import Sound.OSC.FD
-import qualified Data.Map as Map
-import Control.Applicative
-import Control.Concurrent.MVar
-import Data.Hashable
-import Data.Bits
-import Data.Maybe
-import System.Process
-import Control.Concurrent
+import Sound.Tidal.MIDI.Control
 
-import Sound.Tidal.Stream
-import Sound.Tidal.Pattern
-import Sound.Tidal.Parse
-
-channel = Event.Channel 0
-
-bass :: OscShape
-bass = OscShape {path = "/note",
-                 params = [ I "note" Nothing,
-                            F "dur" (Just (0.05)),
-                            F "slide" (Just (-1)),
-                            F "expression" (Just (-1)),
-                            F "octave" (Just (-1)),
-                            F "lforate" (Just (-1)),
-                            F "lfoint" (Just (-1)),
-                            F "pitch1" (Just (-1)),
-                            F "pitch2" (Just (-1)),
-                            F "pitch3" (Just (-1)),
-                            F "attack" (Just (-1)),
-                            F "decay" (Just (-1)),
-                            F "cutoff" (Just (-1)),
-                            F "gate" (Just (-1))
+bass :: ControllerShape
+bass = ControllerShape { params = [
+                            mCC "slide" 5,
+                            mCC "expression" 11,
+                            mCC "octave" 40,
+                            mCC "lforate" 41,
+                            mCC "lfoint" 42,
+                            mCC "pitch1" 43,
+                            mCC "pitch2" 44,
+                            mCC "pitch3" 45,
+                            mCC "attack" 46,
+                            mCC "decay" 47,
+                            mCC "cutoffegint" 48,
+                            mCC "gate" 49
                           ],
-                 cpsStamp = False,
-                 timestamp = NoStamp,
-                 latency = 0,
-                 namedParams = False,
-                 preamble = []
-                }
+                         duration = ("dur", 0.05),
+                         velocity = ("vel", 0.5),
+                         latency = 0.1
+                       }
 
-bassStream = stream "127.0.0.1" 7303 bass
+oscBass = toOscShape bass
 
-note         = makeI bass "note"
-dur          = makeF bass "dur"
-slide        = makeF bass "slide"
-expression   = makeF bass "expression"
-octave       = makeF bass "octave"
-lforate      = makeF bass "lforate"
-lfoint       = makeF bass "lfoint"
-pitch1       = makeF bass "pitch1"
-pitch2       = makeF bass "pitch2"
-pitch3       = makeF bass "pitch3"
-attack       = makeF bass "attack"
-decay        = makeF bass "decay"
-cutoff       = makeF bass "cutoff"
-gate         = makeF bass "gate"
-
-bassnames = map name (tail $ tail $ params bass)
-
-bassproxy latency midiport = 
-   do h <- SndSeq.openDefault SndSeq.Block
-      Client.setName (h :: SndSeq.T SndSeq.OutputMode) "Tidal"
-      c <- Client.getId h
-      p <- Port.createSimple h "out"
-           (Port.caps [Port.capRead, Port.capSubsRead]) Port.typeMidiGeneric
-      conn <- Connect.createTo h p =<< Addr.parse h midiport
-      x <- udpServer "127.0.0.1" 7303
-      forkIO $ loop h conn x
-      return ()
-         where loop h conn x = do m <- recvMessage x
-                                  act h conn m
-                                  loop h conn x
-               act h conn (Just (Message "/note" (note:dur:ctrls))) = 
-                   do -- print $ "Got note " ++ show note
-                      let note' = (fromJust $ d_get note) :: Int
-                          dur' = (fromJust $ d_get dur) :: Float
-                          ctrls' = (map (fromJust . d_get) ctrls) :: [Float]
-                      sendmidi latency h conn (fromIntegral note', dur') ctrls'
-                      return ()
-
-sendmidi latency h conn (note,dur) ctrls = 
-  do forkIO $ do threadDelay latency
-                 Event.outputDirect h $ noteOn conn note 60
-                 threadDelay (floor $ 1000000 * dur)
-                 Event.outputDirect h $ noteOff conn note
-                 return ()
-     let ctrls' = map (floor . (* 127)) ctrls
-         ctrls'' = filter ((>=0) . snd) (zip bassnames ctrls')
-     sequence_ $ map (\(name, ctrl) -> Event.outputDirect h $ makeCtrl conn (ctrlN name ctrl)) ctrls''
-     return ()
-
-ctrlN "slide" v         = (5, v)
-ctrlN "expression" v    = (11, v)
-ctrlN "octave" v        = (40, v)
-ctrlN "lforate" v       = (41, v)
-ctrlN "lfoint" v        = (42, v)
-ctrlN "pitch1" v        = (43, v)
-ctrlN "pitch2" v        = (44, v)
-ctrlN "pitch3" v        = (45, v)
-ctrlN "attack" v        = (46, v)
-ctrlN "decay" v         = (47, v)
-ctrlN "cutoff" v        = (48, v)
-ctrlN "gate" v          = (49, v)
-ctrlN s _               = error $ "no match for " ++ s
-
-noteOn :: Connect.T -> Word8 -> Word8 -> Event.T
-noteOn conn val vel = 
-  Event.forConnection conn 
-  $ Event.NoteEv Event.NoteOn
-  $ Event.simpleNote channel
-                     (Event.Pitch (val))
-                     (Event.Velocity vel)
-
-noteOff :: Connect.T -> Word8 -> Event.T
-noteOff conn val = 
-  Event.forConnection conn 
-  $ Event.NoteEv Event.NoteOff
-  $ Event.simpleNote channel
-                     (Event.Pitch (val))
-                     (Event.normalVelocity)
-
-makeCtrl :: Connect.T -> (Word32, GHC.Int.Int32) -> Event.T
-makeCtrl conn (c, n) = 
-  Event.forConnection conn 
-  $ Event.CtrlEv Event.Controller $ Event.Ctrl 
-                                    channel 
-                                    (Event.Parameter c) 
-                                    (Event.Value n)
-
+note         = makeI oscBass "note"
+dur          = makeF oscBass "dur"
+slide        = makeF oscBass "slide"
+expression   = makeF oscBass "expression"
+octave       = makeF oscBass "octave"
+lforate      = makeF oscBass "lforate"
+lfoint       = makeF oscBass "lfoint"
+pitch1       = makeF oscBass "pitch1"
+pitch2       = makeF oscBass "pitch2"
+pitch3       = makeF oscBass "pitch3"
+attack       = makeF oscBass "attack"
+decay        = makeF oscBass "decay"
+cutoffegint  = makeF oscBass "cutoffegint"
+gate         = makeF oscBass "gate"

--- a/Sound/Tidal/VolcaBeats.hs
+++ b/Sound/Tidal/VolcaBeats.hs
@@ -1,0 +1,72 @@
+module Sound.Tidal.VolcaBeats where
+
+import Sound.Tidal.Stream (makeI, makeF)
+
+import Sound.Tidal.MIDI.Control
+import Control.Applicative
+
+beats :: ControllerShape
+beats = ControllerShape { params = [
+                            mCC "lKick" 40,
+                            mCC "lSnare" 41,
+                            mCC "lLoTom" 42,
+                            mCC "lHiTom" 43,
+                            mCC "lClHat" 44,
+                            mCC "lOpHat" 45,
+                            mCC "lClap" 46,
+                            mCC "lClaves" 47,
+                            mCC "lAgogo" 48,
+                            mCC "lCrash" 49,
+                            mCC "sClap" 50,
+                            mCC "sClaves" 51,
+                            mCC "sAgogo" 52,
+                            mCC "sCrash" 53,
+                            mCC "stutterTime" 54,
+                            mCC "stutterDepth" 55,
+                            mCC "tomDecay" 56,
+                            mCC "clHatDecay" 57,
+                            mCC "opHatDecay" 58,
+                            mCC "hatGrain" 59
+                          ],
+                         duration = ("dur", 0.05),
+                         velocity = ("vel", 0.5),
+                         latency = 0.1
+                       }
+
+oscBeats = toOscShape beats
+
+drum = (makeI oscBeats "note") . (noteN <$>)
+
+lbd = makeF oscBeats "lKick"
+lsn = makeF oscBeats "lSnare"
+llt = makeF oscBeats "lLoTom"
+lht = makeF oscBeats "lHiTom"
+lch = makeF oscBeats "lClHat"
+loh = makeF oscBeats "lOpHat"
+lcp = makeF oscBeats "lClap"
+lcl = makeF oscBeats "lClaves"
+lag = makeF oscBeats "lAgogo"
+lcr = makeF oscBeats "lCrash"
+scp = makeF oscBeats "sClap"
+scl = makeF oscBeats "sClaves"
+sag = makeF oscBeats "sAgogo"
+scr = makeF oscBeats "sCrash"
+stt = makeF oscBeats "stutterTime"
+std = makeF oscBeats "stutterDepth"
+dt = makeF oscBeats "tomDecay"
+dch = makeF oscBeats "clHatDecay"
+doh = makeF oscBeats "opHatDecay"
+dhg = makeF oscBeats "hatGrain"
+
+noteN :: String -> Int
+noteN "bd"  = 36
+noteN "sn"  = 38
+noteN "lt"  = 43
+noteN "ht"  = 50
+noteN "ch"  = 42
+noteN "oh"  = 46
+noteN "cp"  = 39
+noteN "cl"  = 75
+noteN "ag"  = 67
+noteN "cr"  = 49
+noteN _ = 0

--- a/doc/synth-mapping.md
+++ b/doc/synth-mapping.md
@@ -1,0 +1,107 @@
+# Writing a new synth mapping
+
+If a MIDI device you own is not yet supported by tidal-midi you can write a Haskell module to map specific functions to certain parameters of your synth. Since every synth has a more or less different set of parameters the documentation of the various synthesizer parameters and their corresponding MIDI CC number is crucial for writing such a module.
+
+Most user guides for MIDI devices contain an appendix listing all of the supported MIDI commands it can receive. If you haven't got a digital copy of the user guide a simple way to get one is googling it. Due to recent request I will use the Waldorf Streichfett as an example of how to write such a mapping, starting with finding the original user guide pdf and the MIDI mapping information therein. Note that for your own synth MIDI CC values will be different and not all synths have the same capabilities (i.e. you cannot control the same parameters).
+
+## A new synth mapping for _Waldorf Streichfett_
+
+WE Google up the user guide for the synthesizer: waldorf streichfett user guide pdf
+
+Top hit is the [original download link by waldorf music](http://www.waldorf-music.info/downloads/Streichfett/Streichfett%20Manual%20EN.pdf). In any case you should resort to the manufacturers downloads to avoid using an incorrect or otherwise different documentation. Make sure you have the same version of the device as written in the PDF, in this case there doesn't seem to be any revised or newer version of the Streichfett, so we choose this one.
+
+Within the PDF find the section with MIDI Controller numbers and implementation. Most of the time and certainly in this case it can be found within the appendix of the manual. Page 21 lists the MIDI Controller numbers for the synth.
+
+(To keep things simple, I'll not dig into the MIDI implementation listed afterwards, which makes it possible to gain even more control over the synth, this can be done in another tutorial)
+
+As soon as we have these information at hand, we can fire up an editor and start writing our new Haskell module for tidal-midi. ([Make sure you have cloned this repository first](https://github.com/lennart/tidal-midi)
+
+We create a new file within `Sound/Tidal/` in the source folder of tidal-midi called `Streichfett.hs`. In the future it might be wise to start adding namespaces for the various vendors to avoid name collisions (e.g. Waldorf/Streichfett) but for now its fine.
+
+Within this file we first declare our module within Tidal namespace:
+
+```haskell
+module Sound.Tidal.Streichfett where
+```
+
+followed by two needed imports that give access to a few functions I'll list briefly:
+
+```haskell
+import Sound.Tidal.Stream (makeI, makeF)
+```
+taken from Tidal itself we import `makeI` and `makeF` to create parameter functions. These will be used to map our parameter names to named functions. We'll see how these are used later on.
+
+```haskell
+import Sound.Tidal.MIDI.Control
+```
+To create a configuration for Streichfett we need to import the ControllerShape type to define what kind of parameters this synthesizer has and which Midi controller numbers it uses.
+
+We start by defining a ControllerShape that will be passed to any new streams to talk to the Streichfett. You can think of this shape as a way to tell tidal how to create messages sent to the Streichfett. Every time you want to talk to Streichfett, make sure you pass in this shape.
+
+### Looking at how things tie together
+If you remember using tidal-midi the first time, you had to set up your editor to load a module in addition to `Sound.Tidal.MIDI.Output` namely the synthesizer mapping module, e.g. `Sound.Tidal.SimpleSynth`. SimpleSynth defines its own ControllerShape as well, named __keys__. So in order to talk to SimpleSynth via Tidal we need to create a stream we can use from within Haskell that writes messages SimpleSynth can understand, and the __keys__ shape will tell tidal how to do it:
+
+```haskell
+keyStreams <- keyproxy 1 "SimpleSynth virtual input1" keys [1]
+[k1] <- sequence keyStreams
+```
+
+notice how we pass __keys__ to the keyproxy that will in turn create a stream for us that we can later use via `k1`, e.g. `k1 $ note "50" |+| modwheel "0.4"`
+
+So when we are finished with our new module, we'll use `Sound.Tidal.Streichfett` instead and pass in our own controller shape instead of `keys`. Double check this when we are finished, since otherwise you might be talking to your synth with a wrong controller shape and weird things, or, what would be bad: nothing happens.
+
+### Defining our own `ControllerShape`
+At first we define the simplest controller shape we can imagine defining only one parameter for the Streichfett along all need configuration options for a full shape:
+
+```haskell
+fett :: ControllerShape
+fett = ControllerShape {params = [
+                          mCC "phaser" 93
+                        ],
+                        duration = ("dur", 0.05),
+                        latency = 0.1}
+```
+
+That's a lot at first, some things may not be of interest for you now, so let's focus on the main parts. We define our shape named `fett` which is of type `ControllerShape`. We give it three options: `params`, `duration` and `latency`. Ignoring duration and latency for now, `params` is what tells tidal to map names to MIDI control numbers. In this case we define one name `phaser` with the controller number `93` as taken from the Streichfett manual.
+
+### Creating our parameter functions
+Great, tidal-midi now knows about the shape of Streichfett messages (At least, that the `phaser` param is controlled via controller number 93) but sadly we cannot tell tidal to actually change values for this param through patterns. What we will do now is creating something like a handle to send value changes to the `phaser` param
+
+```haskell
+oscFett = toOscShape fett
+
+phaser = makeF oscFett "phaser"
+```
+
+And that's it. If you really cannot wait, this is the minimal working example of your own synth mapping. One last step is needed for really making use of it, namely telling the tidal-midi package about your module. Just add a line to `tidal-midi.cabal` under the key `exposed-modules`:
+
+```
+...
+library
+    Exposed-modules: Sound.Tidal.MIDI.Output
+                   Sound.Tidal.MIDI.Device
+                   Sound.Tidal.MIDI.Control
+                   Sound.Tidal.SimpleSynth
+                   Sound.Tidal.VolcaKeys
+                   Sound.Tidal.VolcaBass
+                   Sound.Tidal.Blofeld
+                   Sound.Tidal.Tetra
+                   Sound.Tidal.Rytm
+                   Sound.Tidal.Synthino
+                   Sound.Tidal.Streichfett
+...
+```
+
+After that do a cabal install within tidal-midi source.
+
+### Using our custom synth mapping in emacs
+
+To use your mapping, we need to integrate it within emacs. If you already have a setup for tidal-midi for e.g. SimpleSynth, the following changes need to be made within your `tidal.el`. Instead of importing `Sound.Tidal.SimpleSynth` import `Sound.Tidal.Streichfett` and instead of passing `keys` to `keyproxy` pass in `fett`.
+
+Restart emacs, start up tidal and try out your new phaser param (assuming k1 is the name of your tidal midi stream):
+
+```haskell
+k1 $ note "50(5,8)" |+| slow 3 (phaser sine1)
+```
+
+have fun and implement all the parameters!

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -1,7 +1,7 @@
 name:                tidal-midi
 version:             0.0.2
 synopsis:            MIDI support for tidal
--- description:         
+-- description:
 homepage:            http://tidal.lurk.org/
 license:             GPL-3
 license-file:        LICENSE
@@ -13,9 +13,20 @@ category:            Sound
 build-type:          Simple
 cabal-version:       >=1.4
 
-Description: Initial MIDI support for Tidal. Currently only supports Volca Keys and Bass synths, and interface is likely to change significantly.
+Description: MIDI support for Tidal. Supports Volca Keys, Bass and Beats and other synths. Interface is likely to change significantly.
 
 library
-  Exposed-modules:     Sound.Tidal.VolcaKeys, Sound.Tidal.VolcaBass
+  Exposed-modules: Sound.Tidal.MIDI.Output
+                   Sound.Tidal.MIDI.Device
+                   Sound.Tidal.MIDI.Control
+                   Sound.Tidal.SimpleSynth
+                   Sound.Tidal.VolcaKeys
+                   Sound.Tidal.VolcaBass
+                   Sound.Tidal.VolcaBeats
+                   Sound.Tidal.Blofeld
+                   Sound.Tidal.Tetra
+                   Sound.Tidal.Rytm
+                   Sound.Tidal.Synthino
+                   Sound.Tidal.MBase01
 
-  Build-depends: base < 5, tidal, alsa-core, alsa-seq, process, hashable, containers, hosc
+  Build-depends: base < 5, tidal, PortMidi, process, hashable, containers, hosc, time, bytestring

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -1,5 +1,5 @@
 name:                tidal-midi
-version:             0.0.2
+version:             0.0.3
 synopsis:            MIDI support for tidal
 -- description:
 homepage:            http://tidal.lurk.org/


### PR DESCRIPTION
This pull request will add the following features:

- Cross platform support on major operating systems (Tested on Windows 7, Mac OS X Yosemite and Debian/Ubuntu Linux)
- MIDI Multi Channel
- Device initialization by name

and more supported devices including:

- Korg Volca Bass/Keys/Beats
- Elektron - Analog Rytm
- Dave Smith Instruments Tetr4
- Waldorf Blofeld
- Jomox MBase01
- Synthino

and for testing purposes supports the free software synth _SimpleSynth_

This pull request will alter the API in the following way:

- All devices are instances of the type `ControllerShape` which define the necessary param names and CC value mappings
- Connections to devices are made by calls to the library function `midiproxy` with the following signature: `Int -> String -> [(ControllerShape, Int)] -> IO [IO (OscPattern -> IO ())]` accepting __latency__ in ms, __Device Name__, a list of pairs of __ControllerShape__ instance and __MIDI Channel__ number. It returns a list of pattern replacers analog to dirt's `d1`...`d9`

__Note__: bumps cabal version to 0.0.3 to make sure people will get this version with experimental midi clock turned off

__Please consider:__ The commit history is a mess, though I am unsure if it is worth the hassle if we clean it up, however if we do not do it now, we won't be able to do it easily later on.

For more information on usage see the corresponding README.md within my fork.