### PR TITLE
Overhaul and docs

### DIFF
--- a/Sound/Tidal/MIDI/Control.hs
+++ b/Sound/Tidal/MIDI/Control.hs
@@ -3,6 +3,7 @@ Mappings between Tidal's 'Sound.Tidal.Stream.Param's and MIDI control changes
 -}
 module Sound.Tidal.MIDI.Control where
 
+import           Control.Applicative ()
 import qualified Sound.Tidal.Stream as S
 import           Sound.Tidal.Tempo (Tempo(cps))
 import qualified Data.Map.Strict as Map

--- a/Sound/Tidal/MIDI/Control.hs
+++ b/Sound/Tidal/MIDI/Control.hs
@@ -3,7 +3,7 @@ Mappings between Tidal's 'Sound.Tidal.Stream.Param's and MIDI control changes
 -}
 module Sound.Tidal.MIDI.Control where
 
-import           Control.Applicative ()
+import           Control.Applicative ((<$>))
 import qualified Sound.Tidal.Stream as S
 import           Sound.Tidal.Tempo (Tempo(cps))
 import qualified Data.Map.Strict as Map

--- a/Sound/Tidal/MIDI/Control.hs
+++ b/Sound/Tidal/MIDI/Control.hs
@@ -7,7 +7,10 @@ import qualified Sound.Tidal.Stream as S
 import           Sound.Tidal.Tempo (Tempo(cps))
 import qualified Data.Map.Strict as Map
 import           Data.Ratio
-import           Sound.Tidal.Params
+import           Sound.Tidal.Params hiding (n_p)
+
+n_p :: S.Param
+n_p = snd $ pI "n" (Just 128)
 
 {-|
 Map a 'Double' to 'Int' using given min/max values

--- a/Sound/Tidal/MIDI/Control.hs
+++ b/Sound/Tidal/MIDI/Control.hs
@@ -1,74 +1,156 @@
+{- |
+Mappings between Tidal's 'Sound.Tidal.Stream.Param's and MIDI control changes
+-}
 module Sound.Tidal.MIDI.Control where
 
 import qualified Sound.Tidal.Stream as S
+import           Sound.Tidal.Tempo (Tempo(cps))
+import qualified Data.Map.Strict as Map
+import           Data.Ratio
+import           Sound.Tidal.Params
 
-import Sound.Tidal.Params
-
+{-|
+Map a 'Double' to 'Int' using given min/max values
+-}
 type RangeMapFunc = (Int, Int) -> Double -> Int
 
+{- | Make sure you apply @cutShape midiShape@ to an 'Sound.Tidal.Stream.ParamMap'
+before passing it into a function wanting this type -}
+type MIDINoteShape = S.ParamMap
+
+{-|
+Describe mapping a Tidal 'Sound.Tidal.Stream.Param' in terms of MIDI
+-}
 data ControlChange =
-  CC { param :: S.Param,
-       midi :: Int,
-       range :: (Int, Int),
-       vdefault :: Double,
-       scalef :: RangeMapFunc
+  CC { param :: S.Param, -- ^ the 'Sound.Tidal.Stream.Param' this control will apply to
+       midi :: Int, -- ^ the MIDI parameter number to map to
+       range :: (Int, Int), -- ^ the range this MIDI parameter accepts, by default this is (0,127)
+       scalef :: RangeMapFunc -- ^ the function to apply mapping floating point values from pattern to MIDI integer values
      }
   | NRPN { param :: S.Param,
            midi :: Int,
            range :: (Int, Int),
-           vdefault :: Double,
            scalef :: RangeMapFunc
          }
   | SysEx { param :: S.Param,
             midi :: Int,
             range :: (Int, Int),
-            vdefault :: Double,
             scalef :: RangeMapFunc
           }
 
+{- |
+A definition for using a Tidal with specific MIDI device type.
+
+By default, every 'ControllerShape' accepts the following 'Sound.Tidal.Stream.Param's:
+
+* 'Sound.Tidal.Params.dur'
+* 'Sound.Tidal.Params.n'
+* 'Sound.Tidal.Params.velocity'
+* 'Sound.Tidal.Params.nudge'
+* 'Sound.Tidal.Params.unit'
+
+which will define the MIDI note to be played.
+-}
 data ControllerShape = ControllerShape {
-  controls :: [ControlChange],
-  latency :: Double
+  controls :: [ControlChange], -- ^ a list of controls that can be understood by a certain device type
+  latency :: Double -- ^ the latency to be used when sending out MIDI messages, this is passed to 'Sound.Tidal.Stream.Shape'
   }
 
+{- |
+A simple shape defining the 'Sound.Tidal.Stream.Param's that are used for generating MIDI notes.
 
+This simplifies splitting a 'Sound.Tidal.Stream.ParamMap' into params for notes and control values.
+-}
+midiShape :: S.Shape
+midiShape = S.Shape {
+  S.params = [     
+     dur_p,
+     n_p,
+     nudge_p,
+     velocity_p,     
+     unit_p
+     ],
+  S.latency = 0,
+  S.cpsStamp = False
+  }
+
+{- |
+Turns a 'MIDINoteShape' into concrete values for scheduling.
+
+-}
+computeTiming :: Tempo -- ^ the current playback speed
+              -> Ratio Integer {- ^ if 'Sound.Tidal.Params.unit' is specified as @cycle@,
+this will be utilized to calculate the note's absolute duration with regard to current cycle length __Note__: this will ignore the specified duration of the Tidal param 'Sound.Tidal.Params.dur' -}
+              -> MIDINoteShape -- ^ A map of 'Sound.Tidal.Stream.Param's that describes the note to be played
+              -> ((Int,Int,Ratio Integer), Double) -- ^ A tuple of a 'Sound.Tidal.MIDI.Output.TimedNote' triplet and the value for 'nudge' to offset this note by
+computeTiming tempo duration m = ((n', v', d'), nudge')
+  where
+    note' = Map.mapMaybe id m
+    unit' = S.svalue $ note' Map.! unit_p    
+    v' = mapRange (0, 127) $ S.fvalue $ note' Map.! velocity_p
+    n' = S.ivalue $  note' Map.! n_p
+    d' = case unit' of
+      "rate" -> byRate
+      "cycle" -> (+) (-0.001) $ (/) duration $ realToFrac $ cps tempo
+      _ -> byRate
+    byRate = realToFrac $ S.fvalue $ note' Map.! dur_p
+
+    nudge' = S.fvalue $ note' Map.! nudge_p
+
+{- | Converts a 'ControllerShape's controls into 'Sound.Tidal.Stream.Param's and makes a 'Sound.Tidal.Stream.Shape'
+This acts as an interface between Tidal's scheduling loop and MIDI scheduling. -}
 toShape :: ControllerShape -> S.Shape
-toShape cs =
-  let params = [dur_p, n_p, velocity_p] ++ params'
-      params' = [param p | p <- (controls cs)]
-  in S.Shape {   S.params = params,
-                 S.cpsStamp = False,
-                 S.latency = latency cs
-             }
+toShape cs = S.Shape {
+  S.params = toParams cs,
+  S.cpsStamp = False,
+  S.latency = latency cs
+  }
 
+{- | A 'RangeMapFunc' that simply passes 'floor's 'Double's.
+
+This can be used if a MIDI parameter of a device has different meanings for each value,
+e.g. the type of oscillator has to be specified by either "0", "1", "2" or "3" each representing a different waveform (sine, tri, square, rand)
+-}
 passThru :: (Int, Int) -> Double -> Int
 passThru (_, _) = floor -- no sanitizing of range…
 
+{- | Default mapping function from Double to Int.
+
+>>> mapRange (0, 127) 0.5
+63
+-}
 mapRange :: (Int, Int) -> Double -> Int
-mapRange (low, high) = floor . (+ (fromIntegral low)) . (* ratio)
+mapRange (low, high) = floor . (+ fromIntegral low) . (* ratio)
   where ratio = fromIntegral $ high - low
 
+-- | Helper function for creating a standard ControlChange for MIDI parameter
 mCC :: S.Param -> Int -> ControlChange
-mCC p m = CC {param=p, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+mCC p m = CC {param=p, midi=m, range=(0, 127), scalef=mapRange }
 
+-- | Helper function for creating a standard ControlChange for a non-registered MIDI parameter
 mNRPN :: S.Param -> Int -> ControlChange
-mNRPN p m = NRPN {param=p, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+mNRPN p m = NRPN {param=p, midi=m, range=(0, 127), scalef=mapRange }
 
-mrNRPN :: S.Param -> Int -> (Int, Int) -> Double -> ControlChange
-mrNRPN p m r d = NRPN {param=p, midi=m, range=r, vdefault=d, scalef=mapRange }
+-- | Helper function for creating a ControlChange for a non-registered MIDI parameter with a custom range
+mrNRPN :: S.Param -> Int -> (Int, Int) -> ControlChange
+mrNRPN p m r = NRPN {param=p, midi=m, range=r, scalef=mapRange }
 
+-- | Translate a 'ControllerShape's controls into a list of 'Sound.Tidal.Stream.Param'
 toParams :: ControllerShape -> [S.Param]
-toParams shape = map param (controls shape)
+toParams shape' = map param (controls shape')
 
+{- | Translate a Tidal 'Sound.Tidal.Stream.Param' into the corresponding MIDI parameter number
+according to a specific 'ControllerShape' -}
 ctrlN :: Num b => ControllerShape -> S.Param -> Maybe b
-ctrlN shape x = fmap fromIntegral $ fmap midi (paramN shape x)
+ctrlN shape' x = (fromIntegral . midi) <$> (paramN shape' x)
 
+-- | Find the first 'ControlChange' that uses 'Sound.Tidal.Stream.Param'
 paramN :: ControllerShape -> S.Param -> Maybe ControlChange
-paramN shape x
+paramN shape' x
   | x `elem` names = paramX $ matching p
-  | otherwise = Nothing -- error $ "No such Controller param: " ++ show x
-  where names = toParams shape
+  | otherwise = Nothing
+  where names = toParams shape'
         paramX [] = Nothing
         paramX (h:_) = Just h
         matching = filter ((== x) . param)
-        p = controls shape
+        p = controls shape'

--- a/Sound/Tidal/MIDI/Device.hs
+++ b/Sound/Tidal/MIDI/Device.hs
@@ -1,17 +1,30 @@
+{-# OPTIONS_HADDOCK not-home #-}
+{-|
+Convenience functions to access "Sound.PortMidi" devices.
+-}
 module Sound.Tidal.MIDI.Device where
 import qualified Sound.PortMidi as PM
 
+{-| Example usage:
+
+>>> putStrLn =<< displayOutputDevices
+ID:	Name
+0:	Midi Through Port-0
+2:	DSI Tetra MIDI 1
+
+-}
 displayOutputDevices :: IO String
 displayOutputDevices = do
   devices <- getIndexedDevices
   return $ displayDevices $ getOutputDevices devices
 
+-- | Readable version of a list of indexed MIDI devices 
 displayDevices :: Show a => [(a, PM.DeviceInfo)] -> String
 displayDevices devices =
   let indices = map (show . fst) devices
       names = map ((":\t"++) . PM.name . snd) devices
       pairs = zipWith (++) indices names
-  in unlines (["ID:\tName"]++pairs)
+  in unlines ("ID:\tName" : pairs)
 
 getOutputDevices :: [(a, PM.DeviceInfo)] -> [(a, PM.DeviceInfo)]
 getOutputDevices = filter (PM.output . snd)
@@ -21,9 +34,9 @@ getIndexedDevices = do
   rawDevices <- getDevices
   return $ zip [0..] rawDevices
 
-getDevices :: IO ([PM.DeviceInfo])
+getDevices :: IO [PM.DeviceInfo]
 getDevices = do
-  PM.initialize
+  _ <- PM.initialize
   count <- PM.countDevices
   mapM PM.getDeviceInfo [0..(count - 1)]
 
@@ -34,3 +47,5 @@ getIDForDeviceName name = do
   case res of
     [] -> return Nothing
     [dev] -> return $ Just $ fromIntegral $ fst dev
+
+

--- a/Sound/Tidal/MIDI/Output.hs
+++ b/Sound/Tidal/MIDI/Output.hs
@@ -1,0 +1,549 @@
+{-# OPTIONS_HADDOCK not-home #-}
+{-|
+A bridge between evaluated Tidal patterns and MIDI events.
+
+This module contains functions necessary to mediate between
+'Sound.Tidal.Time.Event's generated from a Tidal 'Sound.Tidal.Pattern.Pattern'
+and plain MIDI events sent through 'Sound.PortMidi.PMStream'.
+-}
+module Sound.Tidal.MIDI.Output (
+  -- * Types
+  Output(..),
+  OutputState,
+  MidiDeviceMap,
+  TimedNote,
+  -- * Initialization
+  makeConnection,
+  flushBackend,
+  -- * Scheduling
+  sendevents,
+  store,
+  mkStore,
+  storeParams,
+  scheduleTime,
+  -- * Converters
+  toMidiValue,
+  cutShape,
+  stripDefaults,
+  -- * State handling
+  changeState,
+  readState,
+  -- * Low-level functions
+  useOutput,
+  displayOutputDevices,
+  outputDevice,
+  makeRawEvent,
+  noteOn,
+  noteOff,
+  makeCtrl
+                               ) where
+
+-- generics
+import           Control.Monad
+import           Control.Concurrent
+import           Control.Concurrent.MVar()
+import           Data.Bits
+import           Data.List (sortBy, find, partition)
+import qualified Data.Map as Map
+import           Data.Maybe
+import           Data.Ord (comparing)
+import           Data.Ratio (Ratio)
+import           Data.Time (getCurrentTime, UTCTime)
+import           Data.Time.Clock.POSIX
+import           Foreign.C
+import           Numeric
+
+-- Tidal specific
+import           Sound.Tidal.Tempo (Tempo(Tempo))
+import           Sound.Tidal.Stream as S
+
+-- MIDI specific
+import           Sound.Tidal.MIDI.Device
+import           Sound.Tidal.MIDI.Control
+import qualified Sound.PortMidi as PM
+
+type ConnectionCount = Int
+type TickedConnectionCount = Int
+type OutputOnline = Bool
+{- |
+Keep track of virtual streams
+
+* Reflects the number of virtual streams that have already stored their events for this tick. Every time 'TickedConnectionCount' cycles, MIDI events will be sent out.
+* 'ConnectionCount' is increased on every new stream created via `midiSetters`
+* For each channel, currently used params and their values are kept.
+* Output will only be scheduling, once __online__, i.e. when the first stream is initialized
+-}
+type OutputState = (
+  TickedConnectionCount, 
+  ConnectionCount,
+  [ParamMap], 
+  OutputOnline 
+  )
+
+type Tick = Int
+type Onset = Double
+type Offset = Double
+type RelativeOffset = Double
+type MIDITime = (Tempo, Tick, Onset, RelativeOffset)
+type MIDIEvent = (MIDITime, MIDIMessage)
+type MIDIChannel = CLong
+type MIDIStatus = CLong
+type MIDINote = MIDIDatum
+type MIDIVelocity = MIDIDatum
+type MIDIDatum = CLong
+type MIDIDuration = Ratio Integer
+type MIDIMessage = (MIDIChannel, MIDIStatus, MIDINote, MIDIVelocity)
+-- | A Triplet of the deviation from the note @a5@, velocity and duration
+type TimedNote = (CLong, MIDIVelocity, MIDIDuration)
+type SentEvent = (CULong, Double, PM.PMEvent, CULong, UTCTime)
+{-|
+An abstract definition of a physical MIDI Output.
+
+Manages virtual streams to multiple channels of a single connection to a MIDI device.
+-}
+data Output = Output {
+  cshape :: ControllerShape, -- ^ The ControllerShape defining which 'Param's will be available for use
+  conn :: PM.PMStream, -- ^ The physical connection to the device, uses 'PortMidi'
+  buffer :: MVar ([ParamMap], [MIDIEvent]), -- ^ A buffer of currently used 'Param's and their 'Value's as well as a list of 'MIDIEvent's to be sent on the next tick.
+  bufferstate :: MVar OutputState, -- ^ Keeps track of connected virtual streams during one tick
+  midistart :: CULong, -- ^ the MIDI time when this output was created
+  rstart :: UTCTime -- ^ the real time when this output was created
+  }
+
+type MidiMap = Map.Map S.Param (Maybe Int)
+type MidiDeviceMap = Map.Map String Output
+
+
+-- | Initialize a connection to the given MIDI device by Name
+makeConnection :: MVar MidiDeviceMap -- ^ The current list of already connected devices
+               -> String -- ^ The MIDI device name
+               -> Int -- ^ The MIDI channel
+               -> ControllerShape -- ^ The definition of useable 'Control's
+               -> IO (S.ToMessageFunc, Output) -- ^ A function to schedule MIDI events and the output that keeps track of connections
+makeConnection devicesM displayname channel controllershape = do
+  moutput <- useOutput devicesM displayname controllershape
+  case moutput of
+    Just o -> do
+      s <- connected channel displayname o
+      return (s, o)
+    Nothing ->
+      error "Failed initializing MIDI connection"
+
+
+{- |
+Sends out MIDI events once all virtual streams have buffered their events.
+
+This will be called after every tick
+-}
+flushBackend :: Output -> S.Shape -> Tempo -> Int -> IO ()
+flushBackend o shape change ticks = do
+  changeState tickConnections o
+  cycling <- readState isCycling o
+
+  Control.Monad.when cycling (do
+      -- gather last sent params, update state with new
+      let buf = buffer o
+      (states, events) <- takeMVar buf
+
+      ((_,_,newstates,_), (_,_,oldstates,_)) <- changeState' (resetParamStates states) o
+
+      -- find params that were removed
+      let mapDefaults = Map.mapWithKey (\k _ -> defaultValue k)
+          diffs = map mapDefaults $ zipWith Map.difference oldstates newstates
+      -- store additional "reset" events in buffer
+      -- schedule time must be exactly before/ontime with the next regular event to be sent. otherwise we risk
+      -- mixing order of ctrl messages, and resets get overridden
+      -- FIXME: when scheduling, note late CC messages and DROP THEM, otherwise everything is screwed
+      let offset = S.latency shape
+          mididiffs = map ((toMidiMap (cshape o)).(stripShape (toShape $ cshape o))) $ diffs          
+          resetevents = concat $ zipWith (\x y -> makectrls o x (change,ticks,1,offset) y) [1..] mididiffs
+
+      -- send out MIDI events
+      (late, later) <- sendevents o shape change ticks events resetevents
+      -- finally clear buffered ParamMap for next tick
+      putMVar buf (replicate 16 Map.empty, later)
+      let len = length late
+      case len of
+        0 ->
+          return ()
+        _ -> do
+          putStrLn $ showLate $ head late
+          putStrLn $ "and " ++ show (len - 1) ++ " more")
+
+
+-- Scheduling
+
+{- |
+Sends out MIDI events due for this tick.
+-}
+sendevents :: Output -- ^ The connection to be used
+           -> S.Shape -- ^ The shape to be queried for latency
+           -> Tempo -- ^ The current speed
+           -> Tick -- ^ The number of ticks elapsed since start, may be reset when using @cps (-1)@
+           -> [MIDIEvent] -- ^ A list of events potentially needed to be sent
+           -> [MIDIEvent] -- ^ A list of reset events potentially needed to be sent
+           -> IO ([SentEvent], [MIDIEvent]) -- ^ A list of events sent late and a list of events to send later
+sendevents _ _ _ _ [] [] = return ([],[])
+sendevents s shape change ticks evts resets = do
+  -- assumptions:
+  -- all reset events have the same timestamp
+  -- questions:      
+  -- could there be any events in `evts` at all that need reset? or are these just in late from the last tick?
+  let output = conn s
+      toDescriptor midiTime now (o,_,t,e) = (o,t,e, midiTime, now)
+      calcOnsets (a@(tempo, tick, onset, offset), e) = (a, logicalOnset' tempo tick onset offset, e)
+
+  midiTime <- PM.time
+  now <- getCurrentTime
+  let offset = S.latency shape
+      nextTick = logicalOnset' change (ticks+1) 0 offset
+      mkEvent (t, o, e) = (midionset, t, o, makeRawEvent e midionset)
+        where midionset = scheduleTime (midistart s, rstart s) o     
+      onsets = map calcOnsets evts
+      -- calculate temporary scheduling for resetevts
+      resetevts = map calcOnsets resets
+      -- split into events sent now and later (e.g. a noteOff that would otherwise cut off noteOn's in the next tick)
+      (evts', later) = span ((< nextTick).(\(_,o,_) -> o)) $ sortBy (comparing (\(_,o,_) -> o)) onsets
+      -- calculate MIDI time to schedule events, putting time into fn to create PM.PMEvents
+      evts'' = map mkEvent evts'
+      -- a list CC `names` that need to be reset
+      resetccs = map (\(_, _, (_, _, d1, _)) -> d1) resetevts
+      later' = map (\(t,_,e) -> (t,e)) later
+      findCC match list = find (\(_, _, (_, st, d1, _)) -> st == 0xB0 && (d1 `elem` match)) $ reverse list
+
+
+      -- 1. find the ccs that needs reset (search in `later` then in `evts`)
+      (evtstosend, laterevts) = case findCC resetccs later of
+        Nothing -> case findCC resetccs evts' of
+          -- 1c. no events at all need to be reset
+          --      1cI. use the default passed in midionset for resets
+          --      1cII. append `resets` to `evts` FIXME: make sure we really do by timing
+          --      1cIII. send `evts`
+          Nothing -> (evts'' ++ map mkEvent resetevts, later')
+          -- 1b. only `evts` contain a CC to be reset
+          --      1bI. set scheduletime for reset __after__ the latest CC that needs to be reset in `evts`
+          --      1bII. add `resets` to `evts`
+          --      1bIII. send `evts`                
+          Just (_, latestO, _) -> (before ++
+                                      map (
+                                          \(t, o, e) ->
+                                          let midionset = scheduleTime (midistart s, rstart s) latestO
+                                          in (midionset, t,o,makeRawEvent e midionset)
+                                          ) resetevts ++ after, later')
+            where
+              (before, after) = partition (\(m,_,o,_) -> m > scheduleTime (midistart s, rstart s) o) evts''
+
+        -- 1a. `later` contains a cc to be reset, (omit searching in evts)
+        --      1aI. set scheduletime for reset __after__ the latest CC that needs to be reset in `later`
+        --      1aII. add `resetevts` to `later`
+        --      1aIII. send `evts`                
+        Just (latestT, _, _) -> (evts'', later' ++ map (\(_, _, e) -> (latestT, e)) resetevts)
+      evtstosend' = map (\(_,_,_,e) -> e) evtstosend
+      -- filter events that are too late
+      late = map (toDescriptor midiTime now) $ filter (\(_,_,t,_) -> t < realToFrac (utcTimeToPOSIXSeconds now)) evtstosend
+      -- drop late CC events to avoid glitches
+--      evtstosend'' = map (\(_,_,e,_,_) -> e) $ filter (not.isCC) late
+  -- write events for this tick to stream
+  err <- PM.writeEvents output evtstosend'
+
+  case err of
+   PM.NoError -> return (late, laterevts)  -- return events for logging in outer scope
+   e -> do
+     putStrLn ("sending failed: " ++ show e)
+     return (late, laterevts)
+
+isCC :: SentEvent -> Bool
+isCC (_,_,e,_,_) = (0x0f .&. cc) == 0xB0
+  where
+    cc = PM.status $ PM.decodeMsg $ PM.message $ e
+
+
+    
+-- | Buffer a single tick's MIDI events for a single channel of a single connection 
+store :: Output -> Int -> Tempo -> Tick -> Onset -> Offset -> MidiMap -> ParamMap -> IO ()
+store s ch change tick on off ctrls note = storemidi s ch' note' (change, tick, on, offset) ctrls
+    where
+      (note', nudge) = computeTiming' change on off note
+      ch' = fromIntegral ch
+      cshape' = cshape s
+      offset = Sound.Tidal.MIDI.Control.latency cshape' + nudge
+
+{- |
+Returns a function to be called on every tick,
+splits the given @ParamMap@ into MIDI note information
+and CCs.
+-}
+mkStore :: Int -> Output -> IO ToMessageFunc
+mkStore channel s = return $ \ shape change tick (on,off,m) -> do
+                        let ctrls = cutShape shape m
+                            props = cutShape midiShape m
+                            ctrls' = stripDefaults ctrls
+                            ctrls'' = toMidiMap (cshape s) <$> ctrls'
+                            store' = store s channel change tick on off <$> ctrls''
+                        -- store even non-midi params, otherwise removing last ctrl results in a missing reset since diff in `flushBackend` would be empty
+                        -- then buffer ctrl messages to be sent
+                        -- with the appropriate note properties
+                        ($) <$> (storeParams s channel <$> stripDefaults (applyShape' shape m)) <*> (($) <$> store' <*> props)
+
+
+-- | Union the currently stored paramstate for certain channel with the given one
+storeParams :: Output -> Int -> ParamMap -> IO () -> IO ()
+storeParams o ch m action = do
+  modifyMVar_ (buffer o) $ \(states, events) -> do
+    let (before,current:after) = splitAt (ch - 1) states
+        state' = Map.union m current
+        states' = before ++ [state'] ++ after
+    return (states', events)
+  action
+
+-- | Thin wrapper around @computeTiming@ to convert onset/offset into onset/duration relative
+computeTiming' :: Tempo -> Double -> Double -> ParamMap -> (TimedNote, Double)
+computeTiming' tempo on off note = ((fromIntegral n, fromIntegral v, d), nudge)
+  where
+    ((n,v,d), nudge) = computeTiming tempo (realToFrac (off - on) / S.ticksPerCycle) note
+
+{- | Schedule sending all CC's default values.
+Produces an `onTick` handler.
+-}
+connected :: Int -> String -> Output -> IO ToMessageFunc
+connected channel displayname s = do
+  let cshape' = cshape s
+      shape = toShape $ cshape s
+      defaultParams = S.defaultMap shape
+      allctrls = toMidiMap cshape' defaultParams
+  putStrLn ("Successfully initialized Device '" ++ displayname ++ "'")
+  changeState goOnline s
+  now <- getCurrentTime
+  _ <- storeevents s $ makectrls s (fromIntegral channel) (Tempo now 0 1 False 0,0,0,0) allctrls
+  mkStore channel s
+
+-- State handling
+
+readState :: (OutputState -> b) -> Output -> IO b
+readState f o = do
+  s <- readMVar $ bufferstate o
+
+  return $ f s
+
+isCycling :: OutputState -> Bool
+isCycling (0, _, _, True) = True
+isCycling _ = False
+
+-- displayState :: OutputState -> String
+-- displayState (ticked, conns, paramstate, online) = show ticked ++ "/" ++ show conns ++ "[" ++ show online ++ "]" ++ " active params: " ++ show paramstate
+
+changeState :: (OutputState -> OutputState) -> Output -> IO ()
+changeState f o = do
+  _ <- changeState' f o
+  return ()
+
+changeState' :: (OutputState -> OutputState) -> Output -> IO (OutputState, OutputState)
+changeState' f o = do
+  bs <- takeMVar stateM
+  let fs = f bs
+  putMVar stateM fs
+  return (fs, bs)
+    where
+      stateM = bufferstate o
+
+-- | Params in use get overwritten by new ones, except if new ones means _no params_, in this case keep old
+resetParamStates :: [ParamMap] -> OutputState -> OutputState
+resetParamStates newstates (ticked, conns, paramstates, online) = (ticked, conns, zipWith resetParamState newstates paramstates, online)
+
+resetParamState :: ParamMap -> ParamMap -> ParamMap
+resetParamState newstate currentstate
+  | Map.empty == newstate = currentstate -- updating with an empty state is a noop
+  | otherwise = newstate
+
+goOnline :: OutputState -> OutputState
+goOnline (ticked, conns, paramstate, _) = (ticked, conns, paramstate, True)
+
+addConnection :: OutputState -> OutputState
+addConnection (ticked, conns, paramstate, online) = (ticked, conns + 1, paramstate, online)
+
+tickConnections :: OutputState -> OutputState
+tickConnections (ticked, conns, paramstate, online) = ((ticked + 1) `mod` conns, conns, paramstate, online)
+
+-- | open named MIDI output or use cached (PortMIDI doesn't like opening two connections to the same device!)
+useOutput :: MVar MidiDeviceMap -> String -> ControllerShape -> IO (Maybe Output)
+useOutput outsM displayname controllershape = do
+  outs <- readMVar outsM -- blocks
+  let outM = Map.lookup displayname outs -- maybe
+  -- if we have a valid output by now, return
+  case outM of
+    Just o -> do
+      putStrLn "Cached Device Output"
+      changeState addConnection o -- blocks
+      return $ Just o
+    Nothing -> do
+      -- otherwise open a new output and store the result in the mvar
+      devidM <- (>>= maybe (failed displayname "Failed opening MIDI Output Device ID") return) (getIDForDeviceName displayname)
+      econn <- outputDevice devidM 1 controllershape  -- either
+      case econn of
+        Left o -> do
+          changeState addConnection o
+          _ <- swapMVar outsM $ Map.insert displayname o outs
+          return $ Just o
+        Right _ -> return Nothing
+
+
+-- | Turn logicalOnset into MIDITime
+scheduleTime :: (CULong, UTCTime)-> Double -> CULong
+scheduleTime (mstart', rstart') logicalOnset = (+) mstart $ floor $ 1000 * (logicalOnset - rstart'')
+  where
+    rstart'' = realToFrac $ utcTimeToPOSIXSeconds rstart'
+    mstart = fromIntegral mstart'
+    
+-- Converters
+
+{-|
+Convert a @Param@'s @Value@ into a MIDI consumable datum.
+
+Applies range mapping and scaling functions according to @ControllerShape@
+-}
+toMidiValue :: ControllerShape -> S.Param -> Value -> Maybe Int
+toMidiValue s p (VF x) = ($) <$> mscale <*> mrange <*> pure x
+    where
+      mrange = fmap range mcc
+      mscale = fmap scalef mcc
+      mcc = paramN s p
+toMidiValue _ _ (VI x) = Just x
+toMidiValue _ _ (VS _) = Nothing -- ignore strings for now, we might 'read' them later
+
+-- | Translates generic params into midi params
+toMidiMap :: ControllerShape -> S.ParamMap -> MidiMap
+toMidiMap s m = Map.mapWithKey (toMidiValue s) (Map.mapMaybe id m)
+
+-- | Keep only params that are in a given shape, replace missing with defaults
+cutShape :: S.Shape -> ParamMap -> Maybe ParamMap
+cutShape s m = flip Map.intersection (S.defaultMap s) <$> S.applyShape' s m
+
+-- | Keep only params that are in a given shape
+stripShape :: S.Shape -> ParamMap -> ParamMap
+stripShape s = Map.intersection p'
+  where
+    p' = S.defaultMap s
+
+-- | Keep only params that are explicitly set (i.e. not default)
+stripDefaults :: Maybe ParamMap -> Maybe ParamMap
+stripDefaults m = Map.filterWithKey (\k v -> v /= defaultValue k) <$> m
+
+
+-- Event creation
+
+-- FIXME: throws if param cannot be found
+makectrls :: Output -> MIDIChannel -> MIDITime -> MidiMap -> [MIDIEvent]
+makectrls o ch t ctrls = concatMap (\(param', ctrl) -> makeCtrl ch (fromJust $ paramN shape param') (fromIntegral ctrl) t) ctrls'
+  where
+    shape = cshape o
+    ctrls' = filter ((>=0) . snd) $ Map.toList $ Map.mapMaybe id ctrls
+
+makenote :: MIDIChannel -> TimedNote -> MIDITime -> [MIDIEvent]
+makenote ch (note,vel,dur) (tempo,tick,onset,offset) = noteon' ++ noteoff'
+  where
+    noteon' = noteOn ch midinote vel (tempo,tick,onset,offset)
+    noteoff' = noteOff ch midinote (tempo,tick,onset,offset + fromRational dur)
+    midinote = note + 60
+
+makemidi :: Output -> MIDIChannel -> TimedNote -> MIDITime -> MidiMap -> [MIDIEvent]
+makemidi o ch (128,_,_) t ctrls = makectrls o ch t ctrls -- HACK: to send only CC use (n + 60) == 128
+makemidi o ch note t ctrls = makectrls o ch t ctrls ++ makenote ch note t
+
+-- Event buffering
+storemidi :: Output -> MIDIChannel -> TimedNote -> MIDITime -> MidiMap -> IO ()
+storemidi o ch n t ctrls = do
+  _ <- storeevents o $ makemidi o ch n t ctrls
+  return ()
+
+
+makeEvent :: MIDIStatus -> MIDINote -> MIDIChannel -> MIDIVelocity -> MIDITime -> MIDIEvent
+makeEvent st n ch v t = (t, msg)
+  where
+    msg = (ch, st, n, v)
+
+storeevents :: Output -> [MIDIEvent] -> IO (Maybe a)
+storeevents o evts = do
+  let buf = buffer o
+  (paramstate, cbuf) <- takeMVar buf
+  putMVar buf (paramstate, cbuf ++ evts)
+  return Nothing
+
+-- Misc helpers
+
+showLate :: SentEvent -> String
+showLate (o, t, e, m, n) =
+  unwords ["late",
+           show $ (\x -> [PM.status x, PM.data1 x, PM.data2 x]) $ PM.decodeMsg $ PM.message e,
+           "midi now ", show m, " midi onset: ", show o,
+           "onset (relative): ", show $ showFFloat (Just 3) (t - realToFrac (utcTimeToPOSIXSeconds n)) "",
+           ", sched: ", show $ PM.timestamp e]
+
+showEvent :: PM.PMEvent -> String
+showEvent e = show t ++ " " ++ show msg
+  where msg = PM.decodeMsg $ PM.message e
+        t = PM.timestamp e
+
+showRawEvent :: (CULong, MIDITime, Double, PM.PMEvent) -> String
+showRawEvent (_, (_,_,onset,offset), logicalOnset, e) = "(" ++ show onset ++ "," ++ show offset ++ ") / " ++ show logicalOnset ++ " " ++  showEvent e
+
+failed :: (Show a, Show b) => a -> b -> c
+failed di err = error (show err ++ ": " ++ show di)
+
+
+---------------
+-- LOW LEVEL --
+---------------
+
+-- MIDI Event wrapping
+makeRawEvent :: MIDIMessage -> CULong -> PM.PMEvent
+makeRawEvent (ch, st, n, v) = PM.PMEvent msg
+  where msg = PM.encodeMsg $ PM.PMMsg (encodeChannel ch st) n v
+
+
+-- MIDI Utils
+encodeChannel :: MIDIChannel -> MIDIStatus -> CLong
+encodeChannel ch cc = (-) ch 1 .|. cc
+
+
+-- MIDI Messages
+noteOn :: MIDIChannel -> MIDINote -> MIDIVelocity -> MIDITime -> [MIDIEvent]
+noteOn ch val vel t = [makeEvent 0x90 val ch vel t]
+
+noteOff :: MIDIChannel -> MIDINote -> MIDITime -> [MIDIEvent]
+noteOff ch val t = [makeEvent 0x80 val ch 60 t]
+
+makeCtrl :: MIDIChannel -> ControlChange -> MIDIDatum -> MIDITime -> [MIDIEvent]
+makeCtrl ch CC {midi=midi'} n t = makeCC ch (fromIntegral midi') n t -- FIXME: no SysEx support right now
+makeCtrl ch NRPN {midi=midi'} n t = makeNRPN ch (fromIntegral midi') n t
+
+makeCC :: MIDIChannel -> MIDIDatum -> MIDIDatum -> MIDITime -> [MIDIEvent]
+makeCC ch c n t = [makeEvent 0xB0 c ch n t]
+
+makeNRPN :: MIDIChannel -> MIDIDatum -> MIDIDatum -> MIDITime -> [MIDIEvent]
+makeNRPN ch c n t = [
+  nrpn 0x63 ch (shift (c .&. 0x3F80) (-7)) t,
+  nrpn 0x62 ch (c .&. 0x7F) t,
+  nrpn 0x06 ch (shift (n .&. 0x3F80) (-7)) t,
+  nrpn 0x26 ch (n .&. 0x7F) t
+  ]
+  where
+    nrpn = makeEvent 0xB0
+
+
+-- | Creates an 'Output' wrapping a PortMidi device
+outputDevice :: PM.DeviceID -> Int -> ControllerShape -> IO (Either Output PM.PMError)
+outputDevice deviceID latency' shape = do
+  _ <- PM.initialize
+  result <- PM.openOutput deviceID latency'
+  bs <- newMVar (0, 0, replicate 16 Map.empty, False)
+  case result of
+    Left dev ->
+      do
+        info <- PM.getDeviceInfo deviceID
+        time <- getCurrentTime        
+        mstart <- PM.time        
+        putStrLn ("Opened: " ++ show (PM.interface info) ++ ": " ++ show (PM.name info))
+        b <- newMVar (replicate 16 Map.empty, [])
+
+        return (Left Output { cshape=shape, conn=dev, buffer=b, bufferstate=bs, midistart=mstart, rstart=time })
+    Right err -> return (Right err)

--- a/Sound/Tidal/MIDI/Output.hs
+++ b/Sound/Tidal/MIDI/Output.hs
@@ -39,7 +39,7 @@ module Sound.Tidal.MIDI.Output (
                                ) where
 
 -- generics
-import           Control.Applicative ()
+import           Control.Applicative ((<$>), (<*>), pure)
 import           Control.Monad
 import           Control.Concurrent
 import           Control.Concurrent.MVar ()

--- a/Sound/Tidal/MIDI/Output.hs
+++ b/Sound/Tidal/MIDI/Output.hs
@@ -39,9 +39,10 @@ module Sound.Tidal.MIDI.Output (
                                ) where
 
 -- generics
+import           Control.Applicative ()
 import           Control.Monad
 import           Control.Concurrent
-import           Control.Concurrent.MVar()
+import           Control.Concurrent.MVar ()
 import           Data.Bits
 import           Data.List (sortBy, find, partition)
 import qualified Data.Map as Map

--- a/Sound/Tidal/MIDI/Stream.hs
+++ b/Sound/Tidal/MIDI/Stream.hs
@@ -1,368 +1,91 @@
-module Sound.Tidal.MIDI.Stream (midiStream, midiBackend, midiState, midiSetters, midiDevices,send) where
+{-|
+Entry functions for interacting with MIDI devices through Tidal.
+-}
+module Sound.Tidal.MIDI.Stream (midiStream, midiBackend, midiState, midiSetters, midiDevices, displayOutputDevices) where
 
-import Control.Monad.Trans.Maybe
 -- generics
+import           Control.Concurrent
+import           Control.Concurrent.MVar ()
 import qualified Data.Map as Map
-import Data.List (sortBy)
-import Data.Maybe
-import Data.Ord (comparing)
-import Data.Time (getCurrentTime, UTCTime, diffUTCTime)
-import Data.Time.Clock.POSIX
-import Control.Concurrent
-import Control.Concurrent.MVar
-import Data.Bits
-import Foreign.C
-import Control.Applicative
-
-import Numeric
 
 -- Tidal specific
-import Sound.Tidal.Tempo (Tempo, cps, clockedTick)
-import Sound.Tidal.Stream as S
-import Sound.Tidal.Utils
-import Sound.Tidal.Time
-import Sound.Tidal.Transition (transition)
+import           Sound.Tidal.Stream as S
+import           Sound.Tidal.Time
+import           Sound.Tidal.Transition (transition)
 
 -- MIDI specific
-import Sound.Tidal.MIDI.Device
-import Sound.Tidal.MIDI.Control
-import qualified Sound.PortMidi as PM
+import           Sound.Tidal.MIDI.Control
+import           Sound.Tidal.MIDI.Output
 
 
-type ConnectionCount = Int
-type TickedConnectionCount = Int
-type OutputOnline = Bool
-type OutputState = (TickedConnectionCount, ConnectionCount, OutputOnline)
-type MIDITime = (Tempo, Int, Double, Double)
-type MIDIEncoder = CULong -> PM.PMEvent
-type MIDIEvent = (MIDITime, MIDIEncoder)
+{-|
+Create a handle for all currently used 'Output's indexed by their device name.
 
-data Output = Output {
-                       conn :: PM.PMStream,
-                       buffer :: MVar [MIDIEvent],
-                       bufferstate :: MVar OutputState
-                     }
+We use this to cache once opened devices.
 
-type MidiMap = Map.Map S.Param (Maybe Int)
-type MidiDeviceMap = Map.Map String Output
+This will be passed to _every_ initialization of a virtual stream to a MIDI device
+and is necessary since, 'PortMidi' only allows a single connection to a device.
+-}
+midiDevices :: IO (MVar MidiDeviceMap)
+midiDevices = newMVar $ Map.fromList []
 
 
-toMidiEvent :: ControllerShape -> S.Param -> Value -> Maybe Int
-toMidiEvent s p (VF x) = ($) <$> mscale <*> mrange <*> pure x
-    where
-      mrange = fmap range mcc
-      mscale = fmap scalef mcc
-      mcc = paramN s p
-toMidiEvent s p (VI x) = Just x
-toMidiEvent s p (VS x) = Nothing -- ignore strings for now, we might 'read' them later
+{-|
+Connect to a MIDI device with a given name and channel,
+using a 'ControllerShape' to allow customized interaction
+with specific MIDI synths.
 
-toMidiMap :: ControllerShape -> S.ParamMap -> MidiMap
-toMidiMap s m = Map.mapWithKey (toMidiEvent s) (Map.mapMaybe (id) m)
+Needs a 'MidiDeviceMap' to operate, create on using 'midiDevices'!
 
-send s ch cshape shape change tick o ctrls (tdur:tnote:trest) = midi
-    where
-      midi = sendmidi s cshape ch' (note, vel, dur) (change, tick, o, offset) ctrls
-      note = fromIntegral $ ivalue $ snd tnote
-      dur = realToFrac $ fvalue $ snd tdur
-      (vel, nudge) = case length trest of
-        2 -> (mkMidi $ trest !! 1, fvalue $ snd $ trest !! 0)
-        1 -> (mkMidi $ trest !! 0, 0)
-      ch' = fromIntegral ch
-      mkMidi = fromIntegral . floor . (*127) . fvalue . snd
-      offset = ((Sound.Tidal.MIDI.Control.latency cshape) + nudge)
+Usage:
 
-mkSend cshape channel s = return $ (\ shape change tick (o,m) -> do
-                        let defaulted = (S.applyShape' shape m)
-                            -- split ParamMap into Properties and Controls
-                            mpartition = fmap (Map.partitionWithKey (\k _ -> (name k) `elem` ["dur", "n", "velocity", "nudge"])) defaulted
-                            props = fmap fst mpartition
-                            ctrls = fmap snd mpartition
-                            props' = fmap (Map.toAscList) $ fmap (Map.mapMaybe (id)) props
-                            -- only send explicitly set Control values
-                            ctrls' = fmap (Map.filterWithKey (\k v -> v /= (defaultValue k))) ctrls
-                            ctrls'' = fmap (toMidiMap cshape) ctrls'
-                            send' = fmap (send s channel cshape shape change tick o) ctrls''
-                        ($) <$> send' <*> props'
-                        )
+@
+(m1, mt1) <- midiSetters devices "My Synth Controller Device name" 1 synthController getNow
+@
 
-connected cshape channel name s = do
-  putStrLn ("Successfully initialized Device '" ++ name ++ "'")
-  changeState goOnline s
-  mkSend cshape channel s
-
-failed di err = do
-  error (show err ++ ": " ++ show di)
-
-notfound name = do
-  putStrLn "List of Available Device Names"
-  putStrLn =<< displayOutputDevices
-  error ("Device '" ++ show name ++ "' not found")
-
-readState f o = do
-  s <- readMVar $ bufferstate o
-  let fs = f s
-      (ticked, conns, online) = s
-  return fs
-
-isCycling (0, conns, True) = True
-isCycling _ = False
-
-displayState (ticked, conns, online) = show ticked ++ "/" ++ show conns ++ "[" ++ show online ++ "]"
-
-changeState f o = do
-  bs <- takeMVar stateM
-  let fs = f bs
-      (ticked, conns, online) = fs      
-  putMVar stateM $ fs
-    where
-      stateM = bufferstate o
-
-goOnline (ticked, conns, online) = (ticked, conns, True)
-addConnection (ticked, conns, online) = (ticked, conns + 1, online)
-tickConnections (ticked, conns, online) = ((ticked + 1) `mod` conns, conns, online)
-
-useOutput outsM name lat = do
-  outs <- readMVar outsM -- blocks
-  let outM = Map.lookup name outs -- maybe
-  -- if we have a valid output by now, return
-  case outM of
-    Just o -> do
-      putStrLn "Cached Device Output"
-      changeState addConnection o -- blocks
-      return $ Just o
-    Nothing -> do
-      -- otherwise open a new output and store the result in the mvar
-      devidM <- (>>= maybe (failed name "Failed opening MIDI Output Device ID") return) (getIDForDeviceName name)
-      econn <- outputDevice devidM lat  -- either
-      case econn of
-        Left o -> do
-          changeState addConnection o
-          swapMVar outsM $ Map.insert name o outs
-          return $ Just o
-        Right _ -> return Nothing
-
-makeConnection :: MVar (MidiDeviceMap) -> String -> Int -> ControllerShape -> IO ((S.ToMessageFunc), Output)
-makeConnection devicesM deviceName channel cshape = do
-  moutput <- useOutput devicesM deviceName 1
-  case moutput of
-    Just o -> do
-      s <- connected cshape channel deviceName o
-      return (s, o)
-    Nothing ->
-      --failed o
-      error "Failed"
-
-showLate :: (CULong, Double, PM.PMEvent, CULong, UTCTime) -> String
-showLate (o, t, e, m, n) =
-  unwords ["late",
-           (show $ (\x -> [PM.status x, PM.data1 x, PM.data2 x]) $ PM.decodeMsg $ PM.message e),
-           "midi now ", show m, " midi onset: ", show o,
-           "onset (relative): ", show $ showFFloat (Just 3) (t - (realToFrac $ utcTimeToPOSIXSeconds n)) "",
-           ", sched: ", show $ PM.timestamp e]
-
-
--- should only send out events if all connections have ticked
-flushBackend :: Output -> S.Shape -> Tempo -> Int -> IO ()
-flushBackend o shape change ticks = do
-  changeState tickConnections o
-  cycling <- readState isCycling o
-
-  case cycling of
-    True -> do
-      late <- sendevents o shape change ticks
-      let len = length late
-  
-      case len of
-        0 ->
-          return ()
-        _ -> do
-          putStrLn $ showLate $ head late
-          putStrLn $ "and " ++ show (len - 1) ++ " more"
-    False -> do
-      s <- readState displayState o
-      
-      return ()
-      
-
-midiDevices :: IO (MVar (MidiDeviceMap))
-midiDevices = do
-  newMVar $ Map.fromList []
-
-midiBackend d n c cs = do
-  (s, o) <- makeConnection d n c cs
-  return $ Backend s (flushBackend o)
-
-midiStream d n c s = do
-  backend <- midiBackend d n c s
-  stream backend (toShape s)
-
-midiState d n c s = do
-  backend <- midiBackend d n c s
-  S.state backend (toShape s)
-
-midiSetters :: MVar (MidiDeviceMap) -> String -> Int -> ControllerShape -> IO Time -> IO (ParamPattern -> IO (), (Time -> [ParamPattern] -> ParamPattern) -> ParamPattern -> IO ())
+To find the correct name for your device see 'displayOutputDevices'
+-}
+midiSetters :: MVar MidiDeviceMap -- ^ A list of MIDI output devices
+            -> String -- ^ The name of the output device to connect
+            -> Int -- ^ The MIDI Channel to use
+            -> ControllerShape -- ^ The definition of params to be usable
+            -> IO Time -- ^ a method to get the current time
+            -> IO (ParamPattern -> IO (), (Time -> [ParamPattern] -> ParamPattern) -> ParamPattern -> IO ())
 midiSetters d n c s getNow = do
   ds <- midiState d n c s
   return (setter ds, transition getNow ds)
 
 
-toDescriptor midiTime now (o,m,t,e) = (o,t,e, midiTime, now)
+{-|
+Creates a single virtual stream to a MIDI device using a specific 'ControllerShape'
 
-calcOnsets (a@(tempo, tick, onset, offset), e) = (a, logicalOnset' tempo tick onset offset, e)
+Needs a 'MidiDeviceMap' to operate, create one using 'midiDevices'!
+-}
+midiStream :: MVar MidiDeviceMap -> String -> Int -> ControllerShape -> IO (ParamPattern -> IO ())
+midiStream d n c s = do
+  backend <- midiBackend d n c s
+  stream backend (toShape s)
 
-showEvent :: PM.PMEvent -> String
-showEvent e = show t ++ " " ++ show msg 
-  where msg = PM.decodeMsg $ PM.message e
-        t = PM.timestamp e
+{-|
+Creates a single virtual state for a MIDI device using a specific 'ControllerShape'
 
-showRawEvent :: (CULong, MIDITime, Double, PM.PMEvent) -> String
-showRawEvent (midionset, (tempo,tick,onset,offset), logicalOnset, e) = show onset ++ " " ++ " / " ++ show logicalOnset ++ " " ++  showEvent e
+This state can be used to either create a 'Sound.Tidal.Stream.setter' or a 'Sound.Tidal.Transition.transition' from it.
 
-sendevents :: Output -> S.Shape -> Tempo -> Int -> IO ([(CULong, Double, PM.PMEvent, CULong, UTCTime)])
-sendevents stream shape change ticks = do
-  let buf = buffer stream
-      output = conn stream
-  buf' <- tryTakeMVar buf
-  case buf' of
-    Nothing -> do
-      return []
-    Just [] -> do
-      -- make sure we put back an empty buffer
-      putMVar buf []
-      return []
-    (Just evts@(x:xs)) -> do
-          midiTime <- PM.time
-          now <- getCurrentTime
-          
-          let offset = S.latency shape
-              nextTick = logicalOnset' change (ticks+1) 0 offset
-              onsets = map calcOnsets evts
-              -- split into events sent now and later (e.g. a noteOff that would otherwise cut off noteOn's in the next tick)
-              (evts', later) = span ((< nextTick).(\(_,o,_) -> o)) $ sortBy (comparing (\(_,o,_) -> o)) onsets
-              -- calculate MIDI time to schedule events, putting time into fn to create PM.PMEvents
-              evts'' = map (\(t, o, e) -> let midionset = scheduleTime midiTime now o
-                                         in (midionset, t, o, e midionset)) evts'
-              later' = map (\(t,o,e) -> (t,e)) later
-              evts''' = map (\(_,_,_,e) -> e) evts''
-              -- filter events that are too late
-              late = map (toDescriptor midiTime now) $ filter (\(_,_,t,_) -> t < (realToFrac $ utcTimeToPOSIXSeconds now)) $ evts''
-
-          -- write events for this tick to stream
-          err <- PM.writeEvents output evts'''
-          -- store later events for nextTick
-          putMVar buf later'
-          case err of
-            PM.NoError -> do
-              -- return events for logging in outer scope
-              return late
-            e -> do
-              putStrLn "sending failed"
-              return []
+Needs a 'MidiDeviceMap' to operate, create one using 'midiDevices'!
+-}
+midiState :: MVar MidiDeviceMap -> String -> Int -> ControllerShape -> IO (MVar (ParamPattern, [ParamPattern]))
+midiState d n c s = do
+  backend <- midiBackend d n c s
+  S.state backend (toShape s)
 
 
-sendctrls  :: Output -> ControllerShape -> CLong -> MIDITime -> MidiMap -> IO ()
-sendctrls stream shape ch t ctrls = do
-  let ctrls' = filter ((>=0) . snd) $ Map.toList $ Map.mapMaybe (id) ctrls
-  sequence_ $ map (\(param, ctrl) -> makeCtrl stream ch (fromJust $ paramN shape param) (fromIntegral ctrl) t) ctrls' -- FIXME: we should be sure param has ControlChange
-  return ()
+{-|
+Opens a connection to a MIDI device and wraps it in a 'Sound.Tidal.Stream.Backend' implementation.
 
-sendnote :: Output -> t -> CLong -> (CLong, CLong, Double) -> MIDITime -> IO ()
-sendnote stream shape ch (note,vel, dur) (tempo,tick,onset,offset) =
-  do
-    noteOn stream ch midinote vel (tempo,tick,onset,offset)
-    noteOff stream ch midinote (tempo, tick, onset, offset + dur)
-    return ()
-  where midinote = note + 60
+Needs a 'MidiDeviceMap' to operate, create one using 'midiDevices'!
+-}
+midiBackend :: MVar MidiDeviceMap -> String -> Int -> ControllerShape -> IO (Backend a)
+midiBackend d n c cs = do
+  (s, o) <- makeConnection d n c cs
+  return $ Backend s (flushBackend o)
 
-scheduleTime :: CULong -> UTCTime -> Double -> CULong
-scheduleTime mnow' now' logicalOnset = t
-  where
-    now = realToFrac $ utcTimeToPOSIXSeconds $ now'
-    mnow = fromIntegral mnow'
-    t = floor $ mnow + (1000 * (logicalOnset - now)) -- 1 second are 1000 microseconds as is the unit of timestamps in PortMidi
-    
-
-sendmidi :: Output -> ControllerShape -> CLong -> (CLong, CLong, Double) -> MIDITime -> MidiMap -> IO ()
-sendmidi stream shape ch n t ctrls = do
-  sendmidi' stream shape ch n t ctrls
-  return ()
-
-
-sendmidi' stream shape ch (128,vel,dur) t ctrls = do
-  sendctrls stream shape ch t ctrls
-  return ()
-sendmidi' stream shape ch (note,vel,dur) t ctrls = do
-  sendnote stream shape ch (note,vel,dur) t
-  sendctrls stream shape ch t ctrls
-  return ()
-
-
--- MIDI Utils
-encodeChannel :: (Bits a, Num a) => a -> a -> a
-encodeChannel ch cc = (((-) ch 1) .|. cc)
-
-
--- MIDI Messages
-noteOn :: Output -> CLong -> CLong -> CLong -> MIDITime -> IO (Maybe a)
-noteOn o ch val vel t = do
-  let evt = (t, \t' -> makeEvent 0x90 val ch vel t')
-  sendEvent o evt
-
-noteOff :: Output -> CLong -> CLong -> MIDITime -> IO (Maybe a)
-noteOff o ch val t = do
-  let evt = (t, \t' -> makeEvent 0x80 val ch 60 t')
-  sendEvent o evt
-
-makeCtrl :: Output -> CLong -> ControlChange -> CLong -> MIDITime -> IO (Maybe a)
-makeCtrl o ch (CC {midi=midi, range=range}) n t = makeCC o ch (fromIntegral midi) n t
-makeCtrl o ch (NRPN {midi=midi, range=range}) n t = makeNRPN o ch (fromIntegral midi) n t
-
--- This is sending CC
-makeCC :: Output -> CLong -> CLong -> CLong -> MIDITime -> IO (Maybe a)
-makeCC o ch c n t = do
-  let evt = (t, \t' -> makeEvent 0xB0 c ch n t')
-  sendEvent o evt
-
--- This is sending NRPN
-makeNRPN :: Output -> CLong -> CLong -> CLong -> MIDITime -> IO (Maybe a)
-makeNRPN o ch c n t = do
-  let nrpn = makeEvent 0xB0
-      evts = [(t, (\t' -> nrpn 0x63 ch (shift (c .&. 0x3F80) (-7)) t')),
-              (t, (\t' -> nrpn 0x62 ch (c .&. 0x7F) t')),
-              (t, (\t' -> nrpn 0x06 ch (shift (n .&. 0x3F80) (-7)) t')),
-              (t, (\t' -> nrpn 0x26 ch (n .&. 0x7F) t'))
-             ]
-  mapM (sendEvent o) evts
-  return Nothing
-
-
--- Port Midi Wrapper
-
-outputDevice :: PM.DeviceID -> Int -> IO (Either Output PM.PMError)
-outputDevice deviceID latency = do
-  PM.initialize
-  now <- getCurrentTime
-  result <- PM.openOutput deviceID latency
-  bs <- newMVar (0, 0, False)
-  case result of
-    Left dev ->
-      do
-        info <- PM.getDeviceInfo deviceID
-        putStrLn ("Opened: " ++ show (PM.interface info) ++ ": " ++ show (PM.name info))
-        buffer <- newMVar []
-
-        return (Left Output { conn=dev, buffer=buffer, bufferstate=bs })
-    Right err -> return (Right err)
-
-
-makeEvent :: CLong -> CLong -> CLong -> CLong -> CULong -> PM.PMEvent
-makeEvent st n ch v t = PM.PMEvent msg (t)
-  where msg = PM.encodeMsg $ PM.PMMsg (encodeChannel ch st) (n) (v)
-
-sendEvent :: Output -> (MIDITime, (CULong -> PM.PMEvent)) -> IO (Maybe a)
-sendEvent o evt = do
-  let buf = buffer o
-
-  cbuf <- takeMVar buf
-  putMVar buf (cbuf ++ [evt])
-  return Nothing

--- a/Sound/Tidal/MIDI/Tetra.hs
+++ b/Sound/Tidal/MIDI/Tetra.hs
@@ -31,32 +31,32 @@ For very generic control I reused Tidal's own params, like @cutoff@, @attack@, @
 -}
 tetraController :: ControllerShape
 tetraController = ControllerShape { controls = [
-                                  mrNRPN osc1freq_p 0 (0, 120) 0,
-                                  mrNRPN osc1detune_p 1 (0, 100) 0,
-                                  NRPN osc1shape_p 2 (0, 103) 0 passThru,
+                                  mrNRPN osc1freq_p 0 (0, 120),
+                                  mrNRPN osc1detune_p 1 (0, 100),
+                                  NRPN osc1shape_p 2 (0, 103) passThru,
                                   mNRPN osc1glide_p 3,
-                                  NRPN osc1kbd_p 4 (0, 1) 0 passThru,
+                                  NRPN osc1kbd_p 4 (0, 1) passThru,
 
-                                  mrNRPN osc2freq_p 5 (0, 120) 0,
-                                  mrNRPN osc2detune_p 6 (0, 100) 0,
-                                  NRPN osc2shape_p 7 (0, 103) 0 passThru,
+                                  mrNRPN osc2freq_p 5 (0, 120),
+                                  mrNRPN osc2detune_p 6 (0, 100),
+                                  NRPN osc2shape_p 7 (0, 103) passThru,
                                   mNRPN osc2glide_p 8,
-                                  NRPN osc2kbd_p 9 (0, 1) 0 passThru,
+                                  NRPN osc2kbd_p 9 (0, 1) passThru,
 
-                                  NRPN oscsync_p 10 (0, 1) 0 passThru,
-                                  NRPN glidemode_p 11 (0, 3) 0 passThru,
-                                  NRPN oscslop_p 12 (0, 5) 0 passThru,
-                                  mrNRPN oscmix_p 13 (0, 127) 0,
+                                  NRPN oscsync_p 10 (0, 1) passThru,
+                                  NRPN glidemode_p 11 (0, 3) passThru,
+                                  NRPN oscslop_p 12 (0, 5) passThru,
+                                  mrNRPN oscmix_p 13 (0, 127),
 
                                   mNRPN noise_p 14,
-                                  mrNRPN cutoff_p' 15 (0, 164) 0,
+                                  mrNRPN cutoff_p' 15 (0, 164),
                                   mNRPN resonance_p 16,
                                   mNRPN kamt_p 17,
                                   mNRPN audiomod_p 18,
-                                  NRPN fpoles_p 19 (0, 1) 0 passThru,
+                                  NRPN fpoles_p 19 (0, 1) passThru,
 
                                   -- filter envelope
-                                  mrNRPN famt_p 20 (0, 254) 0,
+                                  mrNRPN famt_p 20 (0, 254),
                                   mNRPN fvel_p 21,
                                   mNRPN fdel_p 22,
                                   mNRPN fatk_p 23,
@@ -69,40 +69,40 @@ tetraController = ControllerShape { controls = [
                                   mNRPN pan_p 28,
                                   mNRPN gain_p 29, -- max volume by default
 
-                                  mrNRPN vamt_p 30 (0, 127) 0, -- max vca envelope amount
+                                  mrNRPN vamt_p 30 (0, 127), -- max vca envelope amount
                                   mNRPN vvel_p 31,
                                   mNRPN vdel_p 32,
                                   mNRPN attack_p' 33,
-                                  mrNRPN decay_p' 34 (0, 127) 0,
-                                  mrNRPN sustain_p' 35 (0, 127) 0,
+                                  mrNRPN decay_p' 34 (0, 127),
+                                  mrNRPN sustain_p' 35 (0, 127),
                                   mNRPN release_p' 36,
 
-                                  NRPN lfo1rate_p 37 (0, 166) 0 passThru,
-                                  NRPN lfo1shape_p 38 (0, 4) 0 passThru,
+                                  NRPN lfo1rate_p 37 (0, 166) passThru,
+                                  NRPN lfo1shape_p 38 (0, 4) passThru,
                                   mNRPN lfo1amt_p 39,
-                                  NRPN lfo1dest_p 40 (0, 43) 0 passThru,
-                                  NRPN lfo1sync_p 41 (0, 1) 0 passThru,
+                                  NRPN lfo1dest_p 40 (0, 43) passThru,
+                                  NRPN lfo1sync_p 41 (0, 1) passThru,
 
-                                  NRPN lfo2rate_p 42 (0, 166) 0 passThru, -- unsynced
-                                  NRPN lfo2shape_p 43 (0, 4) 0 passThru,
+                                  NRPN lfo2rate_p 42 (0, 166) passThru, -- unsynced
+                                  NRPN lfo2shape_p 43 (0, 4) passThru,
                                   mNRPN lfo2amt_p 44,
-                                  NRPN lfo2dest_p 45 (0, 43) 0 passThru,
-                                  NRPN lfo2sync_p 46 (0, 1) 0 passThru,
+                                  NRPN lfo2dest_p 45 (0, 43) passThru,
+                                  NRPN lfo2sync_p 46 (0, 1) passThru,
 
-                                  NRPN lfo3rate_p 47 (0, 166) 0 passThru, -- unsynced
-                                  NRPN lfo3shape_p 48 (0, 4) 0 passThru,
+                                  NRPN lfo3rate_p 47 (0, 166) passThru, -- unsynced
+                                  NRPN lfo3shape_p 48 (0, 4) passThru,
                                   mNRPN lfo3amt_p 49,
-                                  NRPN lfo3dest_p 50 (0, 43) 0 passThru,
-                                  NRPN lfo3sync_p 51 (0, 1) 0 passThru,
+                                  NRPN lfo3dest_p 50 (0, 43) passThru,
+                                  NRPN lfo3sync_p 51 (0, 1) passThru,
 
-                                  NRPN lfo4rate_p 52 (0, 166) 0 passThru, -- unsynced
-                                  NRPN lfo4shape_p 53 (0, 4) 0 passThru,
+                                  NRPN lfo4rate_p 52 (0, 166) passThru, -- unsynced
+                                  NRPN lfo4shape_p 53 (0, 4) passThru,
                                   mNRPN lfo4amt_p 54,
-                                  NRPN lfo4dest_p 55 (0, 43) 0 passThru,
-                                  NRPN lfo4sync_p 56 (0, 1) 0 passThru,
+                                  NRPN lfo4dest_p 55 (0, 43) passThru,
+                                  NRPN lfo4sync_p 56 (0, 1) passThru,
 
-                                  NRPN emod_p 57 (0, 43) 0 passThru,
-                                  mrNRPN eamt_p 58 (0, 254) 0,
+                                  NRPN emod_p 57 (0, 43) passThru,
+                                  mrNRPN eamt_p 58 (0, 254),
                                   mNRPN evel_p 59,
                                   mNRPN edel_p 60,
                                   mNRPN eatk_p 61,
@@ -110,70 +110,70 @@ tetraController = ControllerShape { controls = [
                                   mNRPN esus_p 63,
                                   mNRPN erel_p 64,
 
-                                  NRPN mod1src_p 65 (0, 20) 0 passThru,
-                                  mrNRPN mod1amt_p 66 (0, 254) 0,
-                                  NRPN mod1dst_p 67 (0, 47) 0 passThru,
+                                  NRPN mod1src_p 65 (0, 20) passThru,
+                                  mrNRPN mod1amt_p 66 (0, 254),
+                                  NRPN mod1dst_p 67 (0, 47) passThru,
 
-                                  NRPN mod2src_p 68 (0, 20) 0 passThru,
-                                  mrNRPN mod2amt_p 69 (0, 254) 0,
-                                  NRPN mod2dst_p 70 (0, 47) 0 passThru,
+                                  NRPN mod2src_p 68 (0, 20) passThru,
+                                  mrNRPN mod2amt_p 69 (0, 254),
+                                  NRPN mod2dst_p 70 (0, 47) passThru,
 
-                                  NRPN mod3src_p 71 (0, 20) 0 passThru,
-                                  mrNRPN mod3amt_p 72 (0, 254) 0,
-                                  NRPN mod3dst_p 73 (0, 47) 0 passThru,
+                                  NRPN mod3src_p 71 (0, 20) passThru,
+                                  mrNRPN mod3amt_p 72 (0, 254),
+                                  NRPN mod3dst_p 73 (0, 47) passThru,
 
-                                  NRPN mod4src_p 74 (0, 20) 0 passThru,
-                                  mrNRPN mod4amt_p 75 (0, 254) 0,
-                                  NRPN mod4dst_p 76 (0, 47) 0 passThru,
+                                  NRPN mod4src_p 74 (0, 20) passThru,
+                                  mrNRPN mod4amt_p 75 (0, 254),
+                                  NRPN mod4dst_p 76 (0, 47) passThru,
 
-                                  NRPN seq1dst_p 77 (0, 47) 0 passThru,
-                                  NRPN seq2dst_p 78 (0, 47) 0 passThru,
-                                  NRPN seq3dst_p 79 (0, 47) 0 passThru,
-                                  NRPN seq4dst_p 80 (0, 47) 0 passThru,
+                                  NRPN seq1dst_p 77 (0, 47) passThru,
+                                  NRPN seq2dst_p 78 (0, 47) passThru,
+                                  NRPN seq3dst_p 79 (0, 47) passThru,
+                                  NRPN seq4dst_p 80 (0, 47) passThru,
 
-                                  mrNRPN mwhl_p 81 (0, 254) 0,
-                                  NRPN mwhldst_p 82 (0, 47) 0 passThru,
+                                  mrNRPN mwhl_p 81 (0, 254),
+                                  NRPN mwhldst_p 82 (0, 47) passThru,
 
-                                  mrNRPN aftt_p 83 (0, 254) 0,
-                                  NRPN afttdst_p 84 (0, 47) 0 passThru,
+                                  mrNRPN aftt_p 83 (0, 254),
+                                  NRPN afttdst_p 84 (0, 47) passThru,
 
-                                  mrNRPN breath_p 85 (0, 254) 0,
-                                  NRPN breathdst_p 86 (0, 47) 0 passThru,
+                                  mrNRPN breath_p 85 (0, 254),
+                                  NRPN breathdst_p 86 (0, 47) passThru,
 
-                                  mrNRPN mvel_p 87 (0, 254) 0,
-                                  NRPN mveldst_p 88 (0, 47) 0 passThru,
+                                  mrNRPN mvel_p 87 (0, 254),
+                                  NRPN mveldst_p 88 (0, 47) passThru,
 
-                                  mrNRPN foot_p 89 (0, 254) 0,
-                                  NRPN footdst_p 90 (0, 47) 0 passThru,
+                                  mrNRPN foot_p 89 (0, 254),
+                                  NRPN footdst_p 90 (0, 47) passThru,
 
-                                  NRPN kbpm_p 91 (30, 250) 0 passThru,
-                                  NRPN clockdiv_p 92 (0, 12) 0 passThru, -- TODO: document values
+                                  NRPN kbpm_p 91 (30, 250) passThru,
+                                  NRPN clockdiv_p 92 (0, 12) passThru, -- TODO: document values
 
-                                  NRPN bendrng_p 93 (0, 12) 0 passThru,
+                                  NRPN bendrng_p 93 (0, 12) passThru,
 
-                                  NRPN sqntrig_p 94 (0, 4) 0 passThru, -- TODO: document values
-                                  NRPN unisonkey_p 95 (0, 5) 0 passThru, -- TODO: document values
-                                  NRPN unisonmode_p 96 (0, 4) 0 passThru, -- TODO: document values
-                                  NRPN arpmode_p 97 (0, 14) 0 passThru,
+                                  NRPN sqntrig_p 94 (0, 4) passThru, -- TODO: document values
+                                  NRPN unisonkey_p 95 (0, 5) passThru, -- TODO: document values
+                                  NRPN unisonmode_p 96 (0, 4) passThru, -- TODO: document values
+                                  NRPN arpmode_p 97 (0, 14) passThru,
 
-                                  NRPN erepeat_p 98 (0, 1) 0 passThru,
-                                  NRPN unison_p 99 (0, 1) 0 passThru,
+                                  NRPN erepeat_p 98 (0, 1) passThru,
+                                  NRPN unison_p 99 (0, 1) passThru,
 
 
-                                  NRPN arp_p 100 (0, 1) 0 passThru,
-                                  NRPN sqn_p 101 (0, 1) 0 passThru,
+                                  NRPN arp_p 100 (0, 1) passThru,
+                                  NRPN sqn_p 101 (0, 1) passThru,
 
-                                  NRPN mcr1_p 105 (0, 183) 0 passThru,
-                                  NRPN mcr2_p 106 (0, 183) 0 passThru,
-                                  NRPN mcr3_p 107 (0, 183) 0 passThru,
-                                  NRPN mcr4_p 108 (0, 183) 0 passThru,
+                                  NRPN mcr1_p 105 (0, 183) passThru,
+                                  NRPN mcr2_p 106 (0, 183) passThru,
+                                  NRPN mcr3_p 107 (0, 183) passThru,
+                                  NRPN mcr4_p 108 (0, 183) passThru,
 
                                   
                                   mNRPN shape_p 110,
 
-                                  mrNRPN btnfreq_p 111 (0, 127) 0,
-                                  mrNRPN btnvel_p 112 (0, 127) 0,
-                                  NRPN btnmode_p 113 (0, 1) 0 passThru,
+                                  mrNRPN btnfreq_p 111 (0, 127),
+                                  mrNRPN btnvel_p 112 (0, 127),
+                                  NRPN btnmode_p 113 (0, 1) passThru,
 
                                   mNRPN pitch1_p 114,
                                   mNRPN pitch2_p 115,
@@ -182,9 +182,9 @@ tetraController = ControllerShape { controls = [
 
                                   -- left out: editor byte,
 
-                                  mrNRPN ksplitpoint_p 118 (0, 127) 0,
+                                  mrNRPN ksplitpoint_p 118 (0, 127),
                                   -- each patch has layer a/b
-                                  NRPN kmode_p 119 (0, 2) 0 passThru, -- 0: normal, 1: stack, both layers respond to full key range, 2: split at ksplitpoint
+                                  NRPN kmode_p 119 (0, 2) passThru, -- 0: normal, 1: stack, both layers respond to full key range, 2: split at ksplitpoint
                                   mCC notesoff_p 123,
                                   mCC ccreset_p 121,
                                   mCC damp_p 64

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -30,5 +30,6 @@ library
                    Sound.Tidal.MIDI.GMPerc
                    Sound.Tidal.MIDI.Tetra
                    Sound.Tidal.MIDI.SynthParams
+	           Sound.Tidal.MIDI.Output
 
   Build-depends: base < 5, tidal == 0.9, PortMidi == 0.1.6.0, time, containers, transformers

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -31,4 +31,4 @@ library
                    Sound.Tidal.MIDI.Tetra
                    Sound.Tidal.MIDI.SynthParams
 
-  Build-depends: base < 5, tidal == 0.8, PortMidi == 0.1.6.0, time, containers, transformers
+  Build-depends: base < 5, tidal == 0.9, PortMidi == 0.1.6.0, time, containers, transformers

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -1,5 +1,5 @@
 name:                tidal-midi
-version:             0.8
+version:             0.9
 synopsis:            MIDI support for tidal
 -- description:
 homepage:            http://tidal.lurk.org/

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -30,6 +30,6 @@ library
                    Sound.Tidal.MIDI.GMPerc
                    Sound.Tidal.MIDI.Tetra
                    Sound.Tidal.MIDI.SynthParams
-	           Sound.Tidal.MIDI.Output
+                   Sound.Tidal.MIDI.Output
 
   Build-depends: base < 5, tidal == 0.9, PortMidi == 0.1.6.0, time, containers, transformers


### PR DESCRIPTION
@yaxu this will compile against tidal 0.9-dev, check out [lennart/tidal-suite](https://github.com/lennart/tidal-suite) to test before we merge.

Every relevant function within core modules should now be documented to ease bugfixing and understanding of the concepts underneath.

This will bump tidal dependency to 0.9 since we now rely on onset and offsets
begin provided on every tick.

The following breaking changes apply:

- `Control` type does not have a default anymore since we use Tidal's `Param`
- `Param` defaults are restored when params _leave_ a pattern (might be hidden behind an option)
- (Late CC events are **dropped** to avoid out-of-order MIDI messages) _code is in, but commented, since this is really experimental_
- `n`'s default is now `Just 128`, allows to send CC-only patterns more easily.

The following structural changes apply:

- `Stream.hs` is now split into:
  - `Stream.hs` for high-level Tidal related function like `midiSetters` and `midiDevices`
  - `Output.hs` for low-level scheduling of MIDI messages across multiple channels/streams
- `# unit "cycle"` will ignore `dur` and instead calculate inter-onset durations from `cps` _this is subject to change to be in line with SuperDirt_

Known Bugs:

- scheduling is _still_ not good enough, sadly. `noteOff` messages are scheduled 1ms too early to avoid dropped notes when MIDI notes are scheduled 1ms late by either PortMidi or a bug in this code. Maybe this is really MIDI and a rabbit hole...