### PR TITLE
Make it possible to test against tidal development version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
  - git clone --depth 1 --branch 0.9-dev https://github.com/tidalcycles/Tidal
  - pushd Tidal && cabal install && popd
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.24 GHCVER=7.6.3
+    - env: CABALVER=1.16 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.24,ghc-7.6.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=7.8.4
+    - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.4,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=7.10.3
+    - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ before_install:
 
 install:
  - cabal --version
- - BENCH=${BENCH---enable-benchmarks}
- - TEST=${TEST---enable-tests}
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
    then
@@ -43,31 +41,48 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - git clone --branch 0.9-dev --depth 1 https://github.com/tidalcycles/Tidal ${HOME}/Tidal
- - cabal install --builddir ${HOME}/Tidal/dist ${HOME}/Tidal/tidal.cabal
- - cabal new-build ${TEST} ${BENCH} --dep
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - git clone --depth 1 --branch 0.9-dev https://github.com/tidalcycles/Tidal
+ - pushd Tidal && cabal install && popd
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- # this builds all libraries and executables (including tests/benchmarks)
- - cabal new-build ${TEST} ${BENCH} -v2  # -v2 provides useful information for debugging
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
 
- # there's no 'cabal new-test' yet, so let's emulate for now
- - TESTS=( $(awk 'tolower($0) ~ /^test-suite / { print $2 }' *.cabal) );
-   RC=true; for T in ${TESTS[@]}; do echo "== $T ==";
-   if dist-newstyle/build/*/build/$T/$T; then echo "= $T OK =";
-   else echo "= $T FAILED ="; RC=false; fi; done; $RC
- - cabal sdist # test that a source-distribution can be generated
-
- # Check that the resulting source distribution can be built w/o and w tests
- - SRC_BASENAME=$(cabal info . | awk '{print $2;exit}')
- - tar -C dist/ -xf dist/$SRC_BASENAME.tar.gz
- - "echo 'packages: *.cabal' > dist/$SRC_BASENAME/cabal.project"
- - cd dist/$SRC_BASENAME/
- - cabal new-build --disable-tests --disable-benchmarks
- - rm -rf ./dist-newstyle
- - cabal new-build ${TEST} ${BENCH}
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
 
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - git clone --branch 0.9-dev --depth 1 https://github.com/tidalcycles/Tidal ${HOME}/Tidal
+ - cabal install --builddir ${HOME}/Tidal ${HOME}/Tidal/tidal.cabal
  - cabal new-build ${TEST} ${BENCH} --dep
 
 # Here starts the actual work to be performed for the package under test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
  - git clone --branch 0.9-dev --depth 1 https://github.com/tidalcycles/Tidal ${HOME}/Tidal
- - cabal install --builddir ${HOME}/Tidal ${HOME}/Tidal/tidal.cabal
+ - cabal install --builddir ${HOME}/Tidal/dist ${HOME}/Tidal/tidal.cabal
  - cabal new-build ${TEST} ${BENCH} --dep
 
 # Here starts the actual work to be performed for the package under test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ matrix:
   include:
     - env: CABALVER=1.16 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-7.6.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.4,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -11,7 +11,7 @@ Stability:           Experimental
 Copyright:           (c) Alex McLean and other contributors, 2015
 category:            Sound
 build-type:          Simple
-cabal-version:       >=1.4
+cabal-version:       >=1.6
 -- Travis CI integration
 tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1
 Description: MIDI support for Tidal. Supports Volca Keys, Bass and Beats and other synths. Interface is likely to change significantly.
@@ -33,3 +33,7 @@ library
                    Sound.Tidal.MIDI.Output
 
   Build-depends: base < 5, tidal == 0.9, PortMidi == 0.1.6.0, time, containers, transformers
+
+source-repository head
+  type:     git
+  location: https://github.com/tidalcycles/tidal-midi


### PR DESCRIPTION
this pull request should allow travis-ci builds to work, even though the current build version depends on a prerelease version of tidal.

this can be merged when the travis ci build for this pull-request succeeds.