### PR TITLE
0.9 travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,10 @@ install:
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
  - git clone --depth 1 --branch 0.9-dev https://github.com/tidalcycles/Tidal
- - pushd Tidal && cabal install && popd
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - pushd Tidal && cabal install --dry -v > installplan.txt && popd
+ - cat Tidal/installplan.txt > installplan.txt
+ - sed -i -e '1,/^Resolving /d' Tidal/installplan.txt > installplan.txt
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v >> installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -57,6 +59,7 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     pushd Tidal && cabal install && popd
      cabal install --only-dependencies --enable-tests --enable-benchmarks;
    fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
  - git clone --depth 1 --branch 0.9-dev https://github.com/tidalcycles/Tidal
- - pushd Tidal && cabal install --dry -v > installplan.txt && popd
+ - pushd Tidal && git show-ref 0.9-dev && cabal install --dry -v > installplan.txt && popd
  - cat Tidal/installplan.txt > installplan.txt
  - sed -i -e '1,/^Resolving /d' Tidal/installplan.txt > installplan.txt
  - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v >> installplan.txt


### PR DESCRIPTION
this pull request will avoid travis rebuilds of the tidal dependency every time.

cache should get invalidated on a new push to the tidal-0.9-dev branch