### PR TITLE
fix dependency on latest tidal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,9 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - git clone --depth 1 --branch 0.9-dev https://github.com/tidalcycles/Tidal
- - pushd Tidal && git show-ref 0.9-dev && cabal install --dry -v > installplan.txt && popd
- - cat Tidal/installplan.txt > installplan.txt
- - sed -i -e '1,/^Resolving /d' Tidal/installplan.txt > installplan.txt
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v >> installplan.txt
- - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt
+ - cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
  - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     pushd Tidal && cabal install && popd
      cabal install --only-dependencies --enable-tests --enable-benchmarks;
    fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
+    - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,libasound2-dev,libportmidi-dev], sources: [hvr-ghc]}}

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tidal-midi.cabal
+++ b/tidal-midi.cabal
@@ -30,7 +30,7 @@ library
                    Sound.Tidal.MIDI.System1M
                    Sound.Tidal.MIDI.KorgKP3
 
-  Build-depends: base < 5, tidal == 0.8, PortMidi == 0.1.6.0, time, containers, transformers
+  Build-depends: base < 5, tidal == 0.8.2, PortMidi == 0.1.6.0, time, containers, transformers
 
 source-repository head
   type:     git


### PR DESCRIPTION
we should bump to 0.8.1 as we now depend on tidal 0.8.2

- now tests against cabal >= 1.18 (`safe` package requires it.)
- add `Setup.hs` to avoid `cabal check` issues (for hackage & travis)
