### PR TITLE
adding tanzbar, prophet, and minilogue

### DIFF
--- a/Sound/Tidal/MIDI/Minilogue.hs
+++ b/Sound/Tidal/MIDI/Minilogue.hs
@@ -1,0 +1,93 @@
+module Sound.Tidal.MIDI.Minilogue where
+
+import Sound.Tidal.Params
+import Sound.Tidal.MIDI.Control
+
+minilogueController :: ControllerShape
+minilogueController = ControllerShape { controls = [
+		mCC vco1_pitch_p 2,
+		mCC vco2_pitch_p 3,
+		mCC vco1_shape_p 4,
+		mCC vco2_shape_p 5,
+		mCC vco1_level_p 7,
+		mCC vco2_level_p 8,
+		mCC noise_p 1,
+		mCC cross_mod_depth_p 9,
+		mCC pitch_eg_int_p 10,
+		mCC cutoff_p 11,
+		mCC resonance_p 12,
+		mCC filter_eg_int_p 13,
+		mCC amp_attack_p 16,
+		mCC amp_decay_p 17,
+		mCC amp_sustant_p 18,
+		mCC amp_release_p 19,
+		mCC eg_attack_p 20,
+		mCC eg_decay_p 21,
+		mCC eg_sustant_p 22,
+		mCC eg_release_p 23,
+		mCC lfo_rate_p 24,
+		mCC lfo_depth_p 25,
+		mCC voice_depth_p 27,
+		mCC delay_cutoff_p 29,
+		mCC delay_time_p 30,
+		mCC delay_feedback_p 31,
+		mCC vco1_octave_p 64,
+		mCC vco2_octave_p 65,
+		mCC vco1_wave_p 66,
+		mCC vco2_wave_p 67,
+		mCC sync_p 80,
+		mCC ring_p 81,
+		mCC velocity_p 82,
+		mCC key_track_p 83,
+		mCC filter_type_p 84,
+		mCC delay_output_routing_p 88,
+		mCC lfo_target_p 90,
+		mCC lfo_amount_p 91,
+		mCC lfo_wave_p 92
+	],
+ --duration = ("dur", 0.05),
+ --velocity = ("vel", 0.5),
+ latency = 0.1
+}
+
+minilogue = toShape minilogueController
+
+(vco1_pitch, vco1_pitch_p) = pF "vco1_pitch" (Just 0)
+(vco2_pitch, vco2_pitch_p) = pF "vco2_pitch" (Just 0)
+(vco1_shape, vco1_shape_p) = pF "vco1_shape" (Just 0)
+(vco2_shape, vco2_shape_p) = pF "vco2_shape" (Just 0)
+(vco1_level, vco1_level_p) = pF "vco1_level" (Just 0)
+(vco2_level, vco2_level_p) = pF "vco2_level" (Just 0)
+(noise, noise_p) = pF "noise" (Just 0)
+(cross_mod_depth, cross_mod_depth_p) = pF "cross_mod_depth" (Just 0)
+(pitch_eg_int, pitch_eg_int_p) = pF "pitch_eg_int" (Just 0)
+--(cutoff, cutoff_p) = pF "cutoff" (Just 0)
+--(resonance, resonance_p) = pF "resonance" (Just 0)
+(filter_eg_int, filter_eg_int_p) = pF "filter_eg_int" (Just 0)
+(amp_attack, amp_attack_p) = pF "amp_attack" (Just 0)
+(amp_decay, amp_decay_p) = pF "amp_decay" (Just 0)
+(amp_sustant, amp_sustant_p) = pF "amp_sustant" (Just 0)
+(amp_release, amp_release_p) = pF "amp_release" (Just 0)
+(eg_attack, eg_attack_p) = pF "eg_attack" (Just 0)
+(eg_decay, eg_decay_p) = pF "eg_decay" (Just 0)
+(eg_sustant, eg_sustant_p) = pF "eg_sustant" (Just 0)
+(eg_release, eg_release_p) = pF "eg_release" (Just 0)
+(lfo_rate, lfo_rate_p) = pF "lfo_rate" (Just 0)
+(lfo_depth, lfo_depth_p) = pF "lfo_depth" (Just 0)
+(voice_depth, voice_depth_p) = pF "voice_depth" (Just 0)
+(delay_cutoff, delay_cutoff_p) = pF "delay_cutoff" (Just 0)
+(delay_time, delay_time_p) = pF "delay_time" (Just 0)
+(delay_feedback, delay_feedback_p) = pF "delay_feedback" (Just 0)
+(vco1_octave, vco1_octave_p) = pF "vco1_octave" (Just 0)
+(vco2_octave, vco2_octave_p) = pF "vco2_octave" (Just 0)
+(vco1_wave, vco1_wave_p) = pF "vco1_wave" (Just 0)
+(vco2_wave, vco2_wave_p) = pF "vco2_wave" (Just 0)
+(sync, sync_p) = pF "sync" (Just 0)
+(ring, ring_p) = pF "ring" (Just 0)
+--(velocity, velocity_p) = pF "velocity" (Just 0)
+(key_track, key_track_p) = pF "key_track" (Just 0)
+(filter_type, filter_type_p) = pF "filter_type" (Just 0)
+(delay_output_routing, delay_output_routing_p) = pF "delay_output_routing" (Just 0)
+(lfo_target, lfo_target_p) = pF "lfo_target" (Just 0)
+(lfo_amount, lfo_amount_p) = pF "lfo_amount" (Just 0)
+(lfo_wave, lfo_wave_p) = pF "lfo_wave" (Just 0)

--- a/Sound/Tidal/MIDI/Prophet08.hs
+++ b/Sound/Tidal/MIDI/Prophet08.hs
@@ -1,0 +1,95 @@
+module Sound.Tidal.MIDI.Prophet08 where
+
+import Sound.Tidal.Params
+import Sound.Tidal.MIDI.Control
+
+prophetController :: ControllerShape
+prophetController = ControllerShape { controls = [
+	mCC osc1_frequency_p 20,
+	mCC osc1_freq_fine_p 21,
+	mCC osc1_shape_p 22,
+	mCC osc1_glide_p 23,
+	mCC osc2_frequency_p 24,
+	mCC osc2_freq_fine_p 25,
+	mCC osc2_shape_p 26,
+	mCC osc2_glide_p 27,
+	mCC osc_mix_p 28,
+	mCC noise_p 29,
+	mCC filter_frequency_p 102,
+	mCC resonance_p 103,
+	mCC filter_key_amt_p 104,
+	mCC filter_audio_mod_p 105,
+	mCC filter_env_amt_p 106,
+	mCC filter_env_vel_amt_p 107,
+	mCC filter_delay_p 108,
+	mCC filter_attack_p 109,
+	mCC filter_decay_p 110,
+	mCC filter_sustain_p 111,
+	mCC filter_release_p 112 ,
+	mCC vca_level_p 113,
+	mCC pan_spread_p 114,
+	mCC amp_env_amt_p 115,
+	mCC amp_velocity_amt_p 116,
+	mCC amp_delay_p 117,
+	mCC amp_attack_p 118,
+	mCC amp_decay_p 119,
+	mCC amp_sustain_p 75,
+	mCC amp_release_p 76,
+	mCC env3_destination_p 85,
+	mCC env3_amt_p 86,
+	mCC env3_velocity_amt_p 87,
+	mCC env3_delay_p 88,
+	mCC env3_attack_p 89,
+	mCC env3_decay_p 90,
+	mCC env3_sustain_p 77,
+	mCC env3_release_p 78,
+	mCC bpm_p 14,
+	mCC clock_divide_p 15
+	],
+ --duration = ("dur", 0.05),
+ --velocity = ("vel", 0.5),
+ latency = 0.1
+}
+
+prophet = toShape prophetController
+
+(osc1_frequency, osc1_frequency_p) = pF "osc1_frequency" (Just 0)
+(osc1_freq_fine, osc1_freq_fine_p) = pF "osc1_freq_fine" (Just 0)
+(osc1_shape, osc1_shape_p) = pF "osc1_shape" (Just 0)
+(osc1_glide, osc1_glide_p) = pF "osc1_glide" (Just 0)
+(osc2_frequency, osc2_frequency_p) = pF "osc2_frequency" (Just 0)
+(osc2_freq_fine, osc2_freq_fine_p) = pF "osc2_freq_fine" (Just 0)
+(osc2_shape, osc2_shape_p) = pF "osc2_shape" (Just 0)
+(osc2_glide, osc2_glide_p) = pF "osc2_glide" (Just 0)
+(osc_mix, osc_mix_p) = pF "osc_mix" (Just 0)
+(noise, noise_p) = pF "noise" (Just 0)
+(filter_frequency, filter_frequency_p) = pF "filter_frequency" (Just 0)
+--(resonance, resonance_p) = pF "resonance" (Just 0)
+(filter_key_amt, filter_key_amt_p) = pF "filter_key_amt" (Just 0)
+(filter_audio_mod, filter_audio_mod_p) = pF "filter_audio_mod" (Just 0)
+(filter_env_amt, filter_env_amt_p) = pF "filter_env_amt" (Just 0)
+(filter_env_vel_amt, filter_env_vel_amt_p) = pF "filter_env_vel_amt" (Just 0)
+(filter_delay, filter_delay_p) = pF "filter_delay" (Just 0)
+(filter_attack, filter_attack_p) = pF "filter_attack" (Just 0)
+(filter_decay, filter_decay_p) = pF "filter_decay" (Just 0)
+(filter_sustain, filter_sustain_p) = pF "filter_sustain" (Just 0)
+(filter_release, filter_release_p) = pF "filter_release" (Just 0)
+(vca_level, vca_level_p) = pF "vca_level" (Just 0)
+(pan_spread, pan_spread_p) = pF "pan_spread" (Just 0)
+(amp_env_amt, amp_env_amt_p) = pF "amp_env_amt" (Just 0)
+(amp_velocity_amt, amp_velocity_amt_p) = pF "amp_velocity_amt" (Just 0)
+(amp_delay, amp_delay_p) = pF "amp_delay" (Just 0)
+(amp_attack, amp_attack_p) = pF "amp_attack" (Just 0)
+(amp_decay, amp_decay_p) = pF "amp_decay" (Just 0)
+(amp_sustain, amp_sustain_p) = pF "amp_sustain" (Just 0)
+(amp_release, amp_release_p) = pF "amp_release" (Just 0)
+(env3_destination, env3_destination_p) = pF "env3_destination" (Just 0)
+(env3_amt, env3_amt_p) = pF "env3_amt" (Just 0)
+(env3_velocity_amt, env3_velocity_amt_p) = pF "env3_velocity_amt" (Just 0)
+(env3_delay, env3_delay_p) = pF "env3_delay" (Just 0)
+(env3_attack, env3_attack_p) = pF "env3_attack" (Just 0)
+(env3_decay, env3_decay_p) = pF "env3_decay" (Just 0)
+(env3_sustain, env3_sustain_p) = pF "env3_sustain" (Just 0)
+(env3_release, env3_release_p) = pF "env3_release" (Just 0)
+(bpm, bpm_p) = pF "bpm" (Just 0)
+(clock_divide, clock_divide_p) = pF "clock_divide" (Just 0)

--- a/Sound/Tidal/MIDI/Tanzbar.hs
+++ b/Sound/Tidal/MIDI/Tanzbar.hs
@@ -1,0 +1,193 @@
+module Sound.Tidal.MIDI.Tanzbar where
+
+import Sound.Tidal.Params
+import Sound.Tidal.MIDI.Control
+
+
+(bd1_attack, bd1_attack_p) = pF "bd1_attack" (Just 0)
+(bd1_decay, bd1_decay_p) = pF "bd1_decay" (Just 0)
+(bd1_tune, bd1_tune_p) = pF "bd1_tune" (Just 0)
+(bd1_noise, bd1_noise_p) = pF "bd1_noise" (Just 0)
+(bd1_filter, bd1_filter_p) = pF "bd1_filter" (Just 0)
+(bd1_dist, bd1_dist_p) = pF "bd1_dist" (Just 0)
+(bd1_trigger, bd1_trigger_p) = pF "bd1_trigger" (Just 0)
+(bd2_decay, bd2_decay_p) = pF "bd2_decay" (Just 0)
+(bd2_tune, bd2_tune_p) = pF "bd2_tune" (Just 0)
+(bd2_tone, bd2_tone_p) = pF "bd2_tone" (Just 0)
+(sd_tune, sd_tune_p) = pF "sd_tune" (Just 0)
+(sd_d_tune, sd_d_tune_p) = pF "sd_d_tune" (Just 0)
+(sd_snappy, sd_snappy_p) = pF "sd_snappy" (Just 0)
+(sd_sn_decay, sd_sn_decay_p) = pF "sd_sn_decay" (Just 0)
+(sd_tone, sd_tone_p) = pF "sd_tone" (Just 0)
+(sd_tone_decay, sd_tone_decay_p) = pF "sd_tone_decay" (Just 0)
+(sd_pitch, sd_pitch_p) = pF "sd_pitch" (Just 0)
+(rs_tune, rs_tune_p) = pF "rs_tune" (Just 0)
+(cy_decay, cy_decay_p) = pF "cy_decay" (Just 0)
+(cy_tone, cy_tone_p) = pF "cy_tone" (Just 0)
+(cy_tune, cy_tune_p) = pF "cy_tune" (Just 0)
+(oh_decay, oh_decay_p) = pF "oh_decay" (Just 0)
+(hh_tune, hh_tune_p) = pF "hh_tune" (Just 0)
+(hh_decay, hh_decay_p) = pF "hh_decay" (Just 0)
+(cl_tune, cl_tune_p) = pF "cl_tune" (Just 0)
+(cl_decay, cl_decay_p) = pF "cl_decay" (Just 0)
+(cp_decay, cp_decay_p) = pF "cp_decay" (Just 0)
+(cp_filter, cp_filter_p) = pF "cp_filter" (Just 0)
+(cp_attack, cp_attack_p) = pF "cp_attack" (Just 0)
+(cp_trigger, cp_trigger_p) = pF "cp_trigger" (Just 0)
+(htc_tune, htc_tune_p) = pF "htc_tune" (Just 0)
+(htc_decay, htc_decay_p) = pF "htc_decay" (Just 0)
+(htc_noise_on_off, htc_noise_on_off_p) = pF "htc_noise_on_off" (Just 0)
+(htc_tom_conga, htc_tom_conga_p) = pF "htc_tom_conga" (Just 0)
+(mtc_tune, mtc_tune_p) = pF "mtc_tune" (Just 0)
+(mtc_decay, mtc_decay_p) = pF "mtc_decay" (Just 0)
+(mtc_noise_on_off, mtc_noise_on_off_p) = pF "mtc_noise_on_off" (Just 0)
+(mtc_tom_conga, mtc_tom_conga_p) = pF "mtc_tom_conga" (Just 0)
+(ltc_tune, ltc_tune_p) = pF "ltc_tune" (Just 0)
+(ltc_decay, ltc_decay_p) = pF "ltc_decay" (Just 0)
+(ltc_noise_on_off, ltc_noise_on_off_p) = pF "ltc_noise_on_off" (Just 0)
+(ltc_tom_conga, ltc_tom_conga_p) = pF "ltc_tom_conga" (Just 0)
+(tom_noise, tom_noise_p) = pF "tom_noise" (Just 0)
+(cb_tune, cb_tune_p) = pF "cb_tune" (Just 0)
+(cb_decay, cb_decay_p) = pF "cb_decay" (Just 0)
+(ma_decay, ma_decay_p) = pF "ma_decay" (Just 0)
+(set_select, set_select_p) = pF "set_select" (Just 0)
+(track_delay_cv1, track_delay_cv1_p) = pF "track_delay_cv1" (Just 0)
+(track_delay_cv23, track_delay_cv23_p) = pF "track_delay_cv23" (Just 0)
+(track_delay_bd1, track_delay_bd1_p) = pF "track_delay_bd1" (Just 0)
+(track_delay_bd2, track_delay_bd2_p) = pF "track_delay_bd2" (Just 0)
+(track_delay_sd, track_delay_sd_p) = pF "track_delay_sd" (Just 0)
+(track_delay_rs, track_delay_rs_p) = pF "track_delay_rs" (Just 0)
+(track_delay_cy, track_delay_cy_p) = pF "track_delay_cy" (Just 0)
+(track_delay_oh, track_delay_oh_p) = pF "track_delay_oh" (Just 0)
+(track_delay_hh, track_delay_hh_p) = pF "track_delay_hh" (Just 0)
+(track_delay_cl, track_delay_cl_p) = pF "track_delay_cl" (Just 0)
+(track_delay_cp, track_delay_cp_p) = pF "track_delay_cp" (Just 0)
+(track_delay_ltc, track_delay_ltc_p) = pF "track_delay_ltc" (Just 0)
+(track_delay_mtc, track_delay_mtc_p) = pF "track_delay_mtc" (Just 0)
+(track_delay_htc, track_delay_htc_p) = pF "track_delay_htc" (Just 0)
+(track_delay_cb, track_delay_cb_p) = pF "track_delay_cb" (Just 0)
+(track_delay_ma, track_delay_ma_p) = pF "track_delay_ma" (Just 0)
+(bd1, bd1_p) = pF "bd1" (Just 0)
+(bd2, bd2_p) = pF "bd2" (Just 0)
+(sd, sd_p) = pF "sd" (Just 0)
+(rs, rs_p) = pF "rs" (Just 0)
+(cy, cy_p) = pF "cy" (Just 0)
+(oh, oh_p) = pF "oh" (Just 0)
+(hh, hh_p) = pF "hh" (Just 0)
+(cl, cl_p) = pF "cl" (Just 0)
+(cp, cp_p) = pF "cp" (Just 0)
+(ltc, ltc_p) = pF "ltc" (Just 0)
+(mtc, mtc_p) = pF "mtc" (Just 0)
+(htc, htc_p) = pF "htc" (Just 0)
+(cb, cb_p) = pF "cb" (Just 0)
+(ma, ma_p) = pF "ma" (Just 0)
+
+tanzController :: ControllerShape
+tanzController = ControllerShape {
+    controls = [
+    mCC bd1_attack_p 2,
+    mCC bd1_decay_p 64,
+    mCC bd1_tune_p 3,
+    mCC bd1_noise_p 4,
+    mCC bd1_filter_p 5,
+    mCC bd1_dist_p 6,
+    mCC bd1_trigger_p 66,
+    mCC bd2_decay_p 8,
+    mCC bd2_tune_p 9,
+    mCC bd2_tone_p 10,
+    mCC sd_tune_p 11,
+    mCC sd_d_tune_p 12,
+    mCC sd_snappy_p 13,
+    mCC sd_sn_decay_p 67,
+    mCC sd_tone_p 14,
+    mCC sd_tone_decay_p 68,
+    mCC sd_pitch_p 69,
+    mCC rs_tune_p 88,
+    mCC cy_decay_p 70,
+    mCC cy_tone_p 15,
+    mCC cy_tune_p 71,
+    mCC oh_decay_p 75,
+    mCC hh_tune_p 73,
+    mCC hh_decay_p 74,
+    mCC cl_tune_p 16,
+    mCC cl_decay_p 17,
+    mCC cp_decay_p 75,
+    mCC cp_filter_p 18,
+    mCC cp_attack_p 76,
+    mCC cp_trigger_p 77,
+    mCC htc_tune_p 19,
+    mCC htc_decay_p 20,
+    mCC htc_noise_on_off_p 78,
+    mCC htc_tom_conga_p 79,
+    mCC mtc_tune_p 21,
+    mCC mtc_decay_p 22,
+    mCC mtc_noise_on_off_p 80,
+    mCC mtc_tom_conga_p 81,
+    mCC ltc_tune_p 23,
+    mCC ltc_decay_p 24,
+    mCC ltc_noise_on_off_p 82,
+    mCC ltc_tom_conga_p 83,
+    mCC tom_noise_p 84,
+    mCC cb_tune_p 85,
+    mCC cb_decay_p 86,
+    mCC ma_decay_p 87,
+    mCC set_select_p 0,
+    mCC track_delay_cv1_p 89,
+    mCC track_delay_cv23_p 90,
+    mCC track_delay_bd1_p 91,
+    mCC track_delay_bd2_p 92,
+    mCC track_delay_sd_p 93,
+    mCC track_delay_rs_p 94,
+    mCC track_delay_cy_p 95,
+    mCC track_delay_oh_p 96,
+    mCC track_delay_hh_p 97,
+    mCC track_delay_cl_p 98,
+    mCC track_delay_cp_p 99,
+    mCC track_delay_ltc_p 100,
+    mCC track_delay_mtc_p 101,
+    mCC track_delay_htc_p 102,
+    mCC track_delay_cb_p 103,
+    mCC track_delay_ma_p 104,
+    mCC bd1_p 36,
+    mCC bd2_p 37,
+    mCC sd_p 38,
+    mCC rs_p 39,
+    mCC cy_p 40,
+    mCC oh_p 41,
+    mCC hh_p 42,
+    mCC cl_p 43,
+    mCC cp_p 44,
+    mCC ltc_p 45,
+    mCC mtc_p 46,
+    mCC htc_p 47,
+    mCC cb_p 48,
+    mCC ma_p 49
+       ],
+    latency = 0.1
+    }
+
+
+
+
+
+tanz = midinote . (tanzN <$>)
+
+tanzN :: String -> Int
+tanzN "bd1" = 36
+tanzN "bd2" = 37
+tanzN "sd" = 38
+tanzN "rs" = 39
+tanzN "cy" = 40
+tanzN "oh" = 41
+tanzN "hh" = 42
+tanzN "cl" = 43
+tanzN "cp" = 44
+tanzN "ltc" = 45
+tanzN "mtc" = 46
+tanzN "htc" = 47
+tanzN "cb" = 48
+tanzN "ma" = 49
+
+
+-- general shape for stream
+tanzShape = toShape tanzController


### PR DESCRIPTION
Same pull request I made the other day, hopefully correct this time ? 

adding support for Korg’s Minilogue, Dave Smith Instrument’s Prophet 08, and the MFB Tanzbar.