### PR TITLE
add SuperDirt-like `legato`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0
+- add support for `legato` parameter to automatically scale note durations
+
 ## 0.9
 
 - normalize Shape names as lowercased Controller Module name, e.g.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ m1 $ note "0 2" # dur "0.05 0.2"
 m1 $ note "0 2" # dur (scale 0.05 0.3 $ slow 1.5 tri1)
 ```
 
+Alternatively, the `legato` parameter tells Tidal to scale the note
+duration to fill it's "slot" in the pattern.  For example, the following
+will give four notes each a quarter cycle in duration (values of legato
+  greater or less than one will multiply the duration):
+
+```haskell
+m1 $ note "0 1 0 2" # legato "1"
+```
+
 `velocity` has a range from *0 to 1*, and equates to MIDI values *0 to 127*:
 
 ```haskell

--- a/Sound/Tidal/MIDI/Ambika.hs
+++ b/Sound/Tidal/MIDI/Ambika.hs
@@ -41,7 +41,7 @@ ambikaController =
       , mCC lfo3rate_p 61
       , mCC lfo3shape_p 62
       , mCC hold_p 64
-      , mCC legato_p 68
+      , mCC mlegato_p 68
       , mCC env1s_p 70
       , mCC f1res_p 71
       , mCC env1r_p 72
@@ -140,6 +140,8 @@ ambikaSynth = toShape ambikaController
 (lfo4rate, lfo4rate_p) = pF "lfo4rate" (Just 0)
 
 (lfo4shape, lfo4shape_p) = pF "lfo4shape" (Just 0)
+
+(mlegato, mlegato_p) = pF "mlegato" (Just 0)
 
 (env1a, env1a_p) = pF "env1a" (Just 0)
 


### PR DESCRIPTION
I've made changes to Tidal-MIDI to support a cleaner `legato` much like
SuperDirt.

1) As before, duration of notes defaults to the Tidal default: 0.05
seconds, but can be overridden in the source code on a per-synth basis
2) As before, you can further override this live with the `dur`
parameter
3) As before, you can use `unit "cycle"` to get notes with a duration
according to their "slot" in the pattern, like `legato 1` in SuperDirt
4) NEW: `unit "c"` also works as an abbreviation
5) NEW: you can use the `legato` parameter for MIDI just like you would
with SuperDirt. This automatically implies `unit "c"`, you don't have
to specify it
6) NEW: Using `legato` in a pattern overrides any `dur` also present
7) NEW: The Ambika setup was using `legato` as a MIDI CC param, I've
changed the name of this to `mlegato` to avoid conflicts.